### PR TITLE
Fix conditional in material that no longer works

### DIFF
--- a/optimism/material/J2Plastic.py
+++ b/optimism/material/J2Plastic.py
@@ -133,10 +133,9 @@ def energy_density_generic(elStrain, state, props, hardening_model, doUpdate):
 
         isYielding = trialStress > flowStress
 
-        stateInc = lax.cond(isYielding,
-                            lambda e: update_state(e, state, state, props, hardening_model),
-                            lambda e: np.zeros(NUM_STATE_VARS),
-                            elStrain)
+        stateInc = np.where(isYielding,
+                            update_state(elStrain, state, state, props, hardening_model),
+                            np.zeros(NUM_STATE_VARS))
     else:
         stateInc = np.zeros(NUM_STATE_VARS)
     

--- a/optimism/material/MaterialPointUniaxialSimulator.py
+++ b/optimism/material/MaterialPointUniaxialSimulator.py
@@ -7,7 +7,10 @@ from optimism import Objective
 from optimism import TensorMath
 
 
-UniaxialOutput = namedtuple('UniaxialOutput', ['times', 'strainHistory', 'stressHistory', 'cauchyStressHistory', 'energyHistory', 'internalVariableHistory'])
+UniaxialOutput = namedtuple('UniaxialOutput',
+                            ['times', 'strainHistory',
+                             'stressHistory', 'kirchhoffStressHistory',
+                             'energyHistory', 'internalVariableHistory'])
 
 
 class MaterialPointUniaxialSimulator:
@@ -72,7 +75,7 @@ class MaterialPointUniaxialSimulator:
         o = Objective.Objective(obj_func, freeStrains, p)
         
         stressHistory = []
-        cauchyStressHistory = []
+        kirchhoffStressHistory = []
         energyHistory = []
         internalVariableHistory = []
         for i in range(self.steps):
@@ -90,12 +93,12 @@ class MaterialPointUniaxialSimulator:
             cauchy = stress@F.T/J
             
             stressHistory.append(stress[0,0])
-            cauchyStressHistory.append(cauchy[0,0])
+            kirchhoffStressHistory.append(cauchy[0,0])
             energyHistory.append(energyDensity)
             internalVariableHistory.append(internalVariables)
             
         return UniaxialOutput(onp.array(self.times), onp.array(self.strainHistory),
-                              onp.array(stressHistory), onp.array(cauchyStressHistory),
+                              onp.array(stressHistory), onp.array(kirchhoffStressHistory),
                               onp.array(energyHistory), onp.array(internalVariableHistory))
 
     


### PR DESCRIPTION
Replacing the `lax.cond(...)` with an `np.where(...)` fixes the problem for now. It may not be ideal from an efficiency standpoint, because I think this makes the false conditional branch get executed (with the result discarded). I think this is related to this issue: https://github.com/google/jax/issues/3103, which indicates to me that the efficiency problem is unavoidable until Jax solves the issue. In the meantime, this is a workaround.

See b7d1dd2ae9.