### PR TITLE
Feature/differentiable root finder

### DIFF
--- a/optimism/JaxConfig.py
+++ b/optimism/JaxConfig.py
@@ -8,6 +8,7 @@ with warnings.catch_warnings():
     from jax import custom_jvp, custom_vjp
     from jax import jit as jaxJit
     from jax import vmap as jaxVmap
+    from jax.lax import while_loop
     from jax.config import config
 
     
@@ -23,6 +24,11 @@ if jaxDebug:
     
     vmap = jaxVmap
 
+    def while_loop(cond_fun, body_fun, init_val):
+        val = init_val
+        while cond_fun(val):
+            val = body_fun(val)
+        return val
 else:
     jit = jaxJit
     vmap = jaxVmap

--- a/optimism/ScalarRootFind.py
+++ b/optimism/ScalarRootFind.py
@@ -96,10 +96,11 @@ def rtsafe_(f, x0, bracket, settings):
         newtonOutOfRange = ((root - xh)*DF - F) * ((root - xl)*DF - F) >= 0
         newtonDecreasingSlowly = np.abs(2.*F) > np.abs(dxOld*DF)
         dxOld = dx
-        dx = if_then_else(newtonOutOfRange | newtonDecreasingSlowly,
-                          bisectStep,
-                          newtonStep)
-        root += dx
+        xOld = root
+        root = if_then_else(newtonOutOfRange | newtonDecreasingSlowly,
+                            xl + bisectStep,
+                            root + newtonStep)
+        dx = root - xOld
 
         F, DF = f_and_fprime(root)
         

--- a/optimism/ScalarRootFind.py
+++ b/optimism/ScalarRootFind.py
@@ -24,8 +24,8 @@ def find_root(f, x0, bracket, settings):
     x0 : real
         Initial guess for root. The value of x0 should be within the
         range defined by bracket. If not, the initial guess will be
-        automatically moved to the midpoint of the bracket.
-    bracket : list or tuple of 2 reals
+        automatically clipped to the nearest bound.
+    bracket : sequence of 2 reals (list, tuple, numpy array, etc)
         Upper and lower bounds for the root search.
     settings : A settings object from this module
         Sets algorithmic settings.
@@ -71,13 +71,8 @@ def rtsafe_(f, x0, bracket, settings):
 
     # INITIALIZE THE GUESS FOR THE ROOT, THE ''STEP SIZE
     # BEFORE LAST'', AND THE LAST STEP
-    midpoint = 0.5*(xl + xh)
-    x0 = if_then_else(x0 > xh,
-                      midpoint,
-                      x0)
-    x0 = if_then_else(x0 < xl,
-                      midpoint,
-                      x0)
+    bracket = np.array(bracket)
+    x0 = np.clip(x0, np.min(bracket), np.max(bracket))
     dxOld = np.abs(bracket[1] - bracket[0])
     dx = dxOld
 

--- a/optimism/test/testScalarRootFinder.py
+++ b/optimism/test/testScalarRootFinder.py
@@ -10,7 +10,7 @@ from optimism.test import TestFixture
 def f(x): return x**3 - 4.0
 
 
-class RtsafeFixture(TestFixture.TestFixture):
+class ScalarRootFindTestFixture(TestFixture.TestFixture):
 
     def setUp(self):
         self.settings = ScalarRootFind.get_settings()

--- a/optimism/test/testScalarRootFinder.py
+++ b/optimism/test/testScalarRootFinder.py
@@ -72,8 +72,8 @@ class RtsafeFixture(TestFixture.TestFixture):
         myfunc = lambda x, a: x**2 - a
         def my_sqrt(a):
             rootBracket = np.array([float_info.epsilon, 100.0])
-            return ScalarRootFind.rtsafe_(lambda x: myfunc(x, a), 8.0,
-                                          rootBracket, self.settings)
+            return ScalarRootFind.find_root(lambda x: myfunc(x, a), 8.0,
+                                            rootBracket, self.settings)
         r = my_sqrt(9.0)
         self.assertNear(r, 3.0, 12)
 

--- a/optimism/test/testScalarRootFinder.py
+++ b/optimism/test/testScalarRootFinder.py
@@ -67,5 +67,15 @@ class RtsafeFixture(TestFixture.TestFixture):
         x = 3.0
         self.assertNear(df(x), x**(-2/3)/3, 13)
 
+
+    def test_find_root_with_forced_bisection_step(self):
+        myfunc = lambda x, a: x**2 - a
+        def my_sqrt(a):
+            rootBracket = np.array([float_info.epsilon, 100.0])
+            return ScalarRootFind.rtsafe_(lambda x: myfunc(x, a), 8.0,
+                                          rootBracket, self.settings)
+        r = my_sqrt(9.0)
+        self.assertNear(r, 3.0, 12)
+
 if __name__ == '__main__':
     TestFixture.unittest.main()

--- a/optimism/test/testScalarRootFinder.py
+++ b/optimism/test/testScalarRootFinder.py
@@ -89,5 +89,19 @@ class RtsafeFixture(TestFixture.TestFixture):
         expectedRoots = np.array([1.0, 2.0, 3.0, 4.0])
         self.assertArrayNear(F(x), expectedRoots, 12)
 
+
+    def test_solves_when_left_bracket_is_solution(self):
+        rootBracket = np.array([0.0, 1.0])
+        guess = 3.0
+        root = ScalarRootFind.find_root(lambda x: x*(x**2 - 10.0), guess, rootBracket, self.settings)
+        self.assertNear(root, 0.0, 12)
+
+
+    def test_solves_when_right_bracket_is_solution(self):
+        rootBracket = np.array([-1.0, 0.0])
+        guess = 3.0
+        root = ScalarRootFind.find_root(lambda x: x*(x**2 - 10.0), guess, rootBracket, self.settings)
+        self.assertNear(root, 0.0, 12)
+
 if __name__ == '__main__':
     TestFixture.unittest.main()

--- a/optimism/test/testScalarRootFinder.py
+++ b/optimism/test/testScalarRootFinder.py
@@ -89,19 +89,5 @@ class RtsafeFixture(TestFixture.TestFixture):
         expectedRoots = np.array([1.0, 2.0, 3.0, 4.0])
         self.assertArrayNear(F(x), expectedRoots, 12)
 
-
-    # def test_root_find_can_abort_with_vmap_and_jit(self):
-    #     settings = ScalarRootFind.get_settings(max_iters=1)
-    #     myfunc = lambda x, a: x**2 - a
-    #     def my_sqrt(a):
-    #         rootBracket = np.array([float_info.epsilon, 100.0])
-    #         return ScalarRootFind.find_root(lambda x: myfunc(x, a), 25.0,
-    #                                         rootBracket, self.settings)
-    #     F = jit(my_sqrt)
-    #     v = np.array([1.0, 4.0, 9.0, 16.0])
-    #     # this should hang forever
-    #     r = vmap(F, 0)(v)
-    #     print(r)
-
 if __name__ == '__main__':
     TestFixture.unittest.main()


### PR DESCRIPTION
Make a scalar root finding function differentiable so that it can be used in the code.

This root-finding method has been in the code for a long time, but we haven't used it because it wasn't automatically differentiable. I fixed this, and also fixed one or two subtle bugs (and added new tests that catch would catch these bugs). Once this is in place, we can use it to remove repeated code in the material models.