### PR TITLE
Feature/faster high order mesh conversion

### DIFF
--- a/optimism/Mesh.py
+++ b/optimism/Mesh.py
@@ -136,28 +136,52 @@ def mesh_with_nodesets(mesh, nodeSets):
                 mesh.blocks, nodeSets, mesh.sideSets)
 
 
-def create_edges(coords, conns):
-    nTris = conns.shape[0]
-    edgeConns = -np.ones((3*nTris, 2), dtype=np.int_)
-    # edges: [leftElem, lside, rightElem, rside]
-    edges = -np.ones((3*nTris, 4), dtype=np.int_)
-    nEdges = 0
-    
-    for e,eNodes in enumerate(conns):
-        for n in range(3):
-            nn = (n+1)%3
-            edgeConn = [eNodes[n],eNodes[nn]]
-            foundAlready = False
-            for i,existingEdge in enumerate(edgeConns[:nEdges]):
-                if (edgeConn[0]==existingEdge[1]) and (edgeConn[1]==existingEdge[0]):
-                    foundAlready = True
-                    edges = edges.at[i,2:].set([e,n])
-            if not foundAlready:
-                edgeConns = edgeConns.at[nEdges].set(edgeConn)
-                edges = edges.at[nEdges,:2].set([e,n])
-                nEdges += 1
+def create_edges(conns):
+    """Generate topological information about edges in a triangulation.
 
-    return edgeConns[:nEdges], edges[:nEdges]
+    Parameters
+    ----------
+    conns : (nTriangles, 3) array
+        Connectivity table of the triangulation.
+
+    Returns
+    -------
+    edgeConns : (nEdges, 2) array
+        Vertices of each edge. Boundary edges are always in the
+        counter-clockwise sense, so that the interior of the body is on the left
+        side when walking from the first vertex to the second.
+    edges : (nEdges, 4) array
+        Edge-to-triangle topological information. Each row provides the
+        follwing information for each edge: [leftT, leftP, rightT, rightP],
+        where leftT is the ID of the triangle to the left, leftP is the
+        permutation of the edge in the left triangle (edge 0, 1, or 2), rightT
+        is the ID of the triangle to the right, and rightP is the permutation
+        of the edge in the right triangle. If the edge is a boundary edge, the
+        values of rightT and rightP are -1.
+    """
+    nTris = conns.shape[0]
+    allTriFaces = onp.vstack((conns[:, (0,1)], conns[:, (1,2)], conns[:, (2,0)]))
+    foo = onp.sort(allTriFaces, axis=1)
+    bar, i = onp.unique(foo, return_index=True, axis=0)
+    edgeConns = (allTriFaces[i,:])
+
+    nEdges = edgeConns.shape[0]
+    edges = -onp.ones((nEdges, 4), dtype=onp.int_)
+    edgeElementIds = onp.tile(np.arange(nTris), 3)
+    edges[:,0] = edgeElementIds[i]
+    edges[:,1] = i // nTris
+
+    for i, ec in enumerate(edgeConns):
+        rowsMatch = onp.all(onp.flip(ec) == allTriFaces, axis=1)
+        if onp.any(rowsMatch):
+            j = onp.where(rowsMatch)[0]
+            # there should only be one matching row, but take element 0
+            # because j will have the same number of axes (2) as
+            # rowsMatch.
+            edges[i, 2] = edgeElementIds[j]
+            edges[i, 3] = j // nTris
+
+    return edgeConns, edges
 
 
 def create_higher_order_mesh_from_simplex_mesh(mesh, order, useBubbleElement=False, copyNodeSets=False, createNodeSetsFromSideSets=False):
@@ -179,7 +203,7 @@ def create_higher_order_mesh_from_simplex_mesh(mesh, order, useBubbleElement=Fal
     nodeOrdinalOffset = mesh.coords.shape[0] # offset for later node numbering
 
     # step 2/3: mid-edge nodes (excluding vertices)
-    edgeConns, edges = create_edges(mesh.coords, mesh.conns)
+    edgeConns, edges = create_edges(mesh.conns)
     A = np.column_stack((1.0-master1d.coordinates[master1d.interiorNodes],
                          master1d.coordinates[master1d.interiorNodes]))
     edgeCoords = vmap(lambda edgeConn: np.dot(A, mesh.coords[edgeConn,:]))(edgeConns)

--- a/optimism/Mesh.py
+++ b/optimism/Mesh.py
@@ -218,7 +218,7 @@ def create_higher_order_mesh_from_simplex_mesh(mesh, order, useBubbleElement=Fal
         conns = conns.at[elemLeft, edgeMasterNodes].set(edgeNodeOrdinals)
 
         elemRight = edge[2]
-        if elemRight > 0:
+        if elemRight >= 0:
             sideRight = edge[3]
             edgeMasterNodes = master.faceNodes[sideRight][master1d.interiorNodes]
             conns = conns.at[elemRight, edgeMasterNodes].set(np.flip(edgeNodeOrdinals))

--- a/optimism/test/testMesh.py
+++ b/optimism/test/testMesh.py
@@ -106,10 +106,25 @@ class TestSingleMeshFixture(MeshFixture.MeshFixture):
 
         goldInteriorEdgeConns = np.array([[0, 4],
                                           [1, 4],
-                                          [1, 5]])
+                                          [5, 1]])
         goldInteriorEdges = onp.array([[1, 0, 0, 2],
                                        [0, 1, 3, 2],
-                                       [3, 0, 2, 2]])
+                                       [2, 2, 3, 0]])
+
+        for ie, ic in zip(goldInteriorEdges, goldInteriorEdgeConns):
+            foundWithSameSense = onp.any(onp.all(edgeConns == ic, axis=1))
+            foundWithOppositeSense = onp.any(onp.all(edgeConns == onp.flip(ic), axis=1))
+            edgeDataMatches = False
+            if foundWithSameSense:
+                i = onp.where(onp.all(edgeConns == ic, axis=1))
+                edgeData = ie
+            elif foundWithOppositeSense:
+                i = onp.where((onp.all(edgeConns == onp.flip(ic), axis=1)))
+                edgeData = ie[[2, 3, 0, 1]]
+            else:
+                self.fail('edge not found with vertices ' + str(ic))
+            edgeDataMatches = np.all(edges[i,:] == edgeData)
+            self.assertTrue(edgeDataMatches)
 
 
     def test_conversion_to_quadratic_mesh_is_valid(self):

--- a/optimism/test/testMesh.py
+++ b/optimism/test/testMesh.py
@@ -10,7 +10,6 @@ from optimism import Interpolants
 
 #from matplotlib import pyplot as plt
 
-
 class TestSingleMeshFixture(MeshFixture.MeshFixture):
     
     def setUp(self):
@@ -122,20 +121,6 @@ class TestSingleMeshFixture(MeshFixture.MeshFixture):
         # make sure all of the newly created nodes got used in the connectivity
         self.assertArrayEqual(np.unique(newMesh.conns.ravel()), np.arange(nNodes))
 
-        # uncomment the following to inspect higher order mesh
-        # print('coords=\n', newMesh.coords)
-        # print('conns=\n', newMesh.conns)
-        # plt.triplot(newMesh.coords[:,0], newMesh.coords[:,1], newMesh.conns[:,master.vertexNodes])
-        # plt.scatter(newMesh.coords[:,0], newMesh.coords[:,1], marker='o')
-        # plt.show()
-
-        def triangle_inradius(tcoords):
-            area = 0.5*onp.cross(tcoords[1]-tcoords[0], tcoords[2]-tcoords[0])
-            peri = (onp.linalg.norm(tcoords[1]-tcoords[0])
-                    + onp.linalg.norm(tcoords[2]-tcoords[1])
-                    + onp.linalg.norm(tcoords[0]-tcoords[2]))
-            return area/peri
-
         # check that all triangles are valid:
         # compute inradius of each triangle and of the sub-triangle of the mid-edge nodes
         # Both should be nonzero, and parent inradius should be 2x sub-triangle inradius
@@ -152,6 +137,21 @@ class TestSingleMeshFixture(MeshFixture.MeshFixture):
             self.assertGreater(parentArea, 0.0)
             self.assertGreater(childArea, 0.0)
             self.assertAlmostEqual(parentArea, 2.0*childArea, 10)
+
+        # uncomment the following to inspect higher order mesh
+        # print('coords=\n', newMesh.coords)
+        # print('conns=\n', newMesh.conns)
+        # plt.triplot(newMesh.coords[:,0], newMesh.coords[:,1], newMesh.conns[:,master.vertexNodes])
+        # plt.scatter(newMesh.coords[:,0], newMesh.coords[:,1], marker='o')
+        # plt.show()
+
+
+def triangle_inradius(tcoords):
+    area = 0.5*onp.cross(tcoords[1]-tcoords[0], tcoords[2]-tcoords[0])
+    peri = (onp.linalg.norm(tcoords[1]-tcoords[0])
+            + onp.linalg.norm(tcoords[2]-tcoords[1])
+            + onp.linalg.norm(tcoords[0]-tcoords[2]))
+    return area/peri
 
 if __name__ == '__main__':
     MeshFixture.unittest.main()

--- a/optimism/test/testMesh.py
+++ b/optimism/test/testMesh.py
@@ -1,3 +1,6 @@
+import numpy as onp
+from matplotlib import pyplot as plt
+
 from optimism.JaxConfig import *
 from optimism.test import MeshFixture
 from optimism import Mesh
@@ -17,8 +20,8 @@ class TestSingleMeshFixture(MeshFixture.MeshFixture):
 
     
     def setUp(self):
-        self.Nx = 4
-        self.Ny = 3
+        self.Nx = 3
+        self.Ny = 2
         xRange = [0.,1.]
         yRange = [0.,1.]
 
@@ -48,34 +51,115 @@ class TestSingleMeshFixture(MeshFixture.MeshFixture):
     #
 
     
-    def disable_test_edge_conn(self):
-        print('coords=\n',self.mesh.coords)
-        print('conns=\n', self.mesh.conns)
-        edgeConns,edges = Mesh.create_edges(self.mesh.coords, self.mesh.conns)
-        print('edgeConns=\n',edgeConns)
-        print('edges=\n', edges)
+    def test_edge_connectivities(self):
+        edgeConns, _ = Mesh.create_edges(self.mesh.conns)
+
+        goldBoundaryEdgeConns = np.array([[0, 1],
+                                          [1, 2],
+                                          [2, 5],
+                                          [5, 4],
+                                          [4, 3],
+                                          [3, 0]])
+
+        # Check that every boundary edge has been found.
+        # Boundary edges must appear with the same connectivity order,
+        # since by convention boundary edge connectivities go
+        # in the counter-clockwise sense.
+
+        nBoundaryEdges = goldBoundaryEdgeConns.shape[0]
+        boundaryEdgeFound = onp.full(nBoundaryEdges, False)
+
+        for i, be in enumerate(goldBoundaryEdgeConns):
+            rowsMatchingGold = onp.all(edgeConns == be, axis=1)
+            boundaryEdgeFound[i] = onp.any(rowsMatchingGold)
+
+        self.assertTrue(onp.all(boundaryEdgeFound))
+
+        # Check that every interior edge as been found.
+        # Interior edges have no convention defining which
+        # sense the vertices should be ordered, so we check
+        # for both permutations.
+
+        goldInteriorEdgeConns = np.array([[0, 4],
+                                          [1, 4],
+                                          [1, 5]])
+
+        nInteriorEdges = goldInteriorEdgeConns.shape[0]
+        interiorEdgeFound = onp.full(nInteriorEdges, False)
+        for i, e in enumerate(goldInteriorEdgeConns):
+            foundWithSameSense = onp.any(onp.all(edgeConns == e, axis=1))
+            foundWithOppositeSense = onp.any(onp.all(edgeConns == onp.flip(e), axis=1))
+            interiorEdgeFound[i] = foundWithSameSense or foundWithOppositeSense
+
+        self.assertTrue(onp.all(interiorEdgeFound))
 
 
-    def disable_test_higher_order_mesh_creation(self):
+    def test_edge_to_neighbor_cells_data(self):
+        edgeConns, edges = Mesh.create_edges(self.mesh.conns)
+
+        goldBoundaryEdgeConns = np.array([[0, 1],
+                                          [1, 2],
+                                          [2, 5],
+                                          [5, 4],
+                                          [4, 3],
+                                          [3, 0]])
+
+        goldBoundaryEdges = onp.array([[0, 0, -1, -1],
+                                       [2, 0, -1, -1],
+                                       [2, 1, -1, -1],
+                                       [3, 1, -1, -1],
+                                       [1, 1, -1, -1],
+                                       [1, 2, -1, -1]])
+
+        for be, bc in zip(goldBoundaryEdges, goldBoundaryEdgeConns):
+            i = np.where(onp.all(edgeConns == bc, axis=1))
+            self.assertTrue(np.all(edges[i,:] == be))
+
+        goldInteriorEdgeConns = np.array([[0, 4],
+                                          [1, 4],
+                                          [1, 5]])
+        goldInteriorEdges = onp.array([[1, 0, 0, 2],
+                                       [0, 1, 3, 2],
+                                       [3, 0, 2, 2]])
+
+
+    def test_order_2_mesh_creation(self):
         # case with no interior nodes
-        master, master1d = Interpolants.make_master_elements(2)
-        newMesh = Mesh.create_higher_order_mesh_from_simplex_mesh(self.mesh, master, master1d)
+        newMesh = Mesh.create_higher_order_mesh_from_simplex_mesh(self.mesh, 2)
 
-        print('coords=\n', newMesh.coords)
-        print('conns=\n', newMesh.conns)
-        plt.triplot(self.mesh.coords[:,0], self.mesh.coords[:,1], newMesh.conns[:,master.vertexNodes])
-        plt.scatter(newMesh.coords[:,0], newMesh.coords[:,1], marker='o')
+        nNodes = newMesh.coords.shape[0]
+        self.assertEqual(nNodes, 15)
 
+        # make sure all of the newly created nodes got used in the connectivity
+        self.assertArrayEqual(np.unique(newMesh.conns.ravel()), np.arange(nNodes))
+
+        # uncomment the following to inspect higher order mesh
+        # print('coords=\n', newMesh.coords)
+        # print('conns=\n', newMesh.conns)
+        # plt.triplot(self.mesh.coords[:,0], self.mesh.coords[:,1], newMesh.conns[:,master.vertexNodes])
+        # plt.scatter(newMesh.coords[:,0], newMesh.coords[:,1], marker='o')
+        # plt.show()
+
+
+    def test_order_3_mesh_creation(self):
         # case with interior nodes
         master, master1d = Interpolants.make_master_elements(3)
-        newMesh = Mesh.create_higher_order_mesh_from_simplex_mesh(self.mesh, master, master1d)
+        #newMesh = Mesh.create_higher_order_mesh_from_simplex_mesh(self.mesh, master, master1d)
+        newMesh = Mesh.create_higher_order_mesh_from_simplex_mesh(self.mesh, 3)
 
-        print('coords=\n', newMesh.coords)
-        print('conns=\n', newMesh.conns)
-        plt.figure()
-        plt.triplot(self.mesh.coords[:,0], self.mesh.coords[:,1], newMesh.conns[:,master.vertexNodes])
-        plt.scatter(newMesh.coords[:,0], newMesh.coords[:,1], marker='o')
-        plt.show()
+        nNodes = newMesh.coords.shape[0]
+        self.assertEqual(nNodes, 28)
+
+        # make sure all of the newly created nodes got used in the connectivity
+        self.assertArrayEqual(np.unique(newMesh.conns.ravel()), np.arange(nNodes))
+
+        # uncomment the following to inspect higher order mesh
+        # print('coords=\n', newMesh.coords)
+        # print('conns=\n', newMesh.conns)
+        # plt.figure()
+        # plt.triplot(self.mesh.coords[:,0], self.mesh.coords[:,1], newMesh.conns[:,master.vertexNodes])
+        # plt.scatter(newMesh.coords[:,0], newMesh.coords[:,1], marker='o')
+        # plt.show()
 
 
             


### PR DESCRIPTION
There is a utility for converting a mesh of linear triangles to higher order elements. Part of the algorithm [here](https://github.com/sandialabs/optimism/blob/4f94d76d88c7a16b17f4fff4f1f51fb5ed922151/optimism/Mesh.py#L181) adds nodes to each edge. To do this, there is a function for generating the edge-triangle topological information in [this](https://github.com/sandialabs/optimism/blob/4f94d76d88c7a16b17f4fff4f1f51fb5ed922151/optimism/Mesh.py#L139) function. Its algorithm has the ideal computational complexity, but there is a heavy speed penalty in practice because the code is not vectorized and is implemented with nested loops. This PR re-implements the edge topology information function using built-in numpy functions for drastically better timing.

I also caught a subtle bug in the higher-order mesh conversion that wasn't triggered in any of the existing tests. I fixed it and added a new test that would have caught it.

Fixes #14 