### PR TITLE
Feature/improve material uniaxial tester

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,2 +1,3 @@
 *.npz
 *.vtk
+*.pdf

--- a/examples/material_test/MaterialTest.py
+++ b/examples/material_test/MaterialTest.py
@@ -1,0 +1,47 @@
+"""Demonstrate the material testing tools."""
+
+from matplotlib import pyplot as plt
+
+from optimism.JaxConfig import *
+from optimism.material import MaterialUniaxialSimulator
+from optimism.material import J2Plastic
+
+
+E = 69e9
+nu = 0.34
+Y0 = 380e6
+n = 5.8
+ep0 = 1.5e-3
+properties = {"elastic modulus": E,
+              "poisson ratio": nu,
+              "yield strength": Y0,
+              "hardening model": "power law",
+              "hardening exponent": n,
+              "reference plastic strain": ep0,
+              "strain measure": "logarithmic"}
+material = J2Plastic.create_material_model_functions(properties)
+
+strainRate = 1e-3
+
+def constant_log_strain_rate(t):
+    return np.expm1(strainRate*t)
+
+maxTime = 360.0
+
+
+
+if __name__ == "__main__":
+    uniaxialData = MaterialUniaxialSimulator.run(material, constant_log_strain_rate,
+                                                 maxTime, steps=100)
+
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(8.5, 11))
+
+    ax1.plot(uniaxialData.strainHistory[:,0,0], uniaxialData.stressHistory[:,0,0]/1e6)
+    ax1.set_xlabel("Engineering strain [-]")
+    ax1.set_ylabel("Nominal Stress [MPa]")
+    
+    ax2.plot(uniaxialData.strainHistory[:,0,0], uniaxialData.internalVariableHistory[:,J2Plastic.EQPS])
+    ax2.set_xlabel("Engineering strain [-]")
+    ax2.set_ylabel("Equivalent plastic strain")
+
+    plt.savefig("aluminum.pdf")

--- a/optimism/material/LinearElastic.py
+++ b/optimism/material/LinearElastic.py
@@ -79,5 +79,5 @@ def log_strain(dispGrad):
     J = np.linalg.det(F)
     traceStrain = np.log(J)
     CIso = J**(-2.0/3.0)*F.T@F
-    devStrain = 0.5*logm_iss(CIso)
+    devStrain = TensorMath.mtk_log_sqrt(CIso)
     return devStrain + traceStrain/3.0*np.identity(3)

--- a/optimism/material/MaterialUniaxialSimulator.py
+++ b/optimism/material/MaterialUniaxialSimulator.py
@@ -9,91 +9,83 @@ from optimism import TensorMath
 
 UniaxialOutput = namedtuple('UniaxialOutput', ['time', 'strainHistory', 'stressHistory',
                                                'energyHistory', 'internalVariableHistory'])
+UniaxialOutput.__doc__ = """\
+Output from a uniaxial tension test on a material.
+
+Attributes
+----------
+time: array
+    discrete time points in the unixial data
+strainHistory: array
+    displacement gradient tensor at each time point
+stressHistory: array
+    Piola stress tensor at each time point
+energyHistory: array
+    Potential function value at each time point
+internalVariableHistory: array
+    Collection of internal variables for the given material at each time point.
+"""
 
 
-class MaterialUniaxialSimulator:
-    """Generates the uniaxial response of a given potential density function
-
-    The non-axial strain components are determined by minimizing the potential,
-    which coincides with stress-free conditions for every stress component
-    besides the uniaxial stress.
-
-    Methods
+def run(materialModel, strain_history, maxTime, steps=10):
+    """ Generates the uniaxial response of a given material
+    Args
+    ----
+    materialModel: MaterialModel object
+        Material to subject to uniaxial stress test
+    strain_history: callable (float) -> float
+        The tensile strain as a function of time
+    maxTime: float
+        Upper limit of the time interval
+    steps: int
+        Number of time steps to take
+    
+    Returns
     -------
-    run():
-      Launches the simluation with the given parameters
+    UniaxialOutput: named tuple of constitutive output
     """
-
-    def __init__(self, materialModel, strain_history, maxTime, steps=10):
-        """Constructor
-
-        Args
-        ----
-        materialModel: MaterialModel object
-            Material to subject to uniaxial stress test
-        strain_history: callable (float) -> float
-            The tensile strain as a function of time
-        maxTime: float
-            Upper limit of the time interval
-        steps: int
-            Number of time steps to take
-        """
-        self.steps = steps
-        self.times = np.linspace(0.0, maxTime, num=steps)
-        self.uniaxialStrainHistory = strain_history(self.times)
-        self.energy_density = materialModel.compute_energy_density
-        self.converged_energy_density_and_stress = jit(value_and_grad(materialModel.compute_output_energy_density))
-        self.update = jit(materialModel.compute_state_new)
-        self.compute_initial_state = materialModel.compute_initial_state
-    
-    def run(self):
-        """ Execute the uniaxial test
-        Returns
-        -------
-        UniaxialOutput: named tuple of constitutive output
-        """
+    timePoints = np.linspace(0.0, maxTime, num=steps)
+    uniaxialStrainHistory = strain_history(timePoints)
+    energy_density = materialModel.compute_energy_density
+    converged_energy_density_and_stress = jit(value_and_grad(materialModel.compute_output_energy_density))
+    update = jit(materialModel.compute_state_new)
         
-        def obj_func(freeStrains, p):
-            strain = self.makeStrainTensor(freeStrains, p)
-            return self.energy_density(strain, p[1])
+    def obj_func(freeStrains, p):
+        strain = makeStrainTensor_(freeStrains, p)
+        return energy_density(strain, p[1])
 
-        solverSettings = EqSolver.get_settings()
-        internalVariables =  self.compute_initial_state()
-        freeStrains = np.zeros(2)
+    solverSettings = EqSolver.get_settings()
+    internalVariables =  materialModel.compute_initial_state()
+    freeStrains = np.zeros(2)
         
-        p = Objective.Params(self.uniaxialStrainHistory[0], internalVariables)
-        o = Objective.Objective(obj_func, freeStrains, p)
+    p = Objective.Params(uniaxialStrainHistory[0], internalVariables)
+    o = Objective.Objective(obj_func, freeStrains, p)
 
-        strainHistory = []
-        stressHistory = []
-        kirchhoffStressHistory = []
-        energyHistory = []
-        internalVariableHistory = []
-        for i in range(self.steps):
-            p = Objective.param_index_update(p, 0, self.uniaxialStrainHistory[i])
+    strainHistory = []
+    stressHistory = []
+    kirchhoffStressHistory = []
+    energyHistory = []
+    internalVariableHistory = []
+    for i in range(steps):
+        p = Objective.param_index_update(p, 0, uniaxialStrainHistory[i])
 
-            freeStrains = EqSolver.nonlinear_equation_solve(o, freeStrains, p, solverSettings, useWarmStart=True)
-            strain = self.makeStrainTensor(freeStrains, p)
-            internalVariables = self.update(strain, internalVariables)
-            energyDensity,stress = self.converged_energy_density_and_stress(strain, internalVariables)
-            p = Objective.param_index_update(p, 1, internalVariables)
-            o.p = p
+        freeStrains = EqSolver.nonlinear_equation_solve(o, freeStrains, p, solverSettings, useWarmStart=True)
+        strain = makeStrainTensor_(freeStrains, p)
+        internalVariables = update(strain, internalVariables)
+        energyDensity,stress = converged_energy_density_and_stress(strain, internalVariables)
+        p = Objective.param_index_update(p, 1, internalVariables)
+        o.p = p
 
-            F = np.identity(3) + strain
-            J = np.linalg.det(F)
-            cauchy = stress@F.T/J
-
-            strainHistory.append(strain)
-            stressHistory.append(stress)
-            energyHistory.append(energyDensity)
-            internalVariableHistory.append(internalVariables)
+        strainHistory.append(strain)
+        stressHistory.append(stress)
+        energyHistory.append(energyDensity)
+        internalVariableHistory.append(internalVariables)
             
-        return UniaxialOutput(onp.array(self.times), onp.array(strainHistory),
-                              onp.array(stressHistory), onp.array(energyHistory),
-                              onp.array(internalVariableHistory))
+    return UniaxialOutput(onp.array(timePoints), onp.array(strainHistory),
+                          onp.array(stressHistory), onp.array(energyHistory),
+                          onp.array(internalVariableHistory))
 
     
-    @staticmethod
-    def makeStrainTensor(freeStrains, p):
-        uniaxialStrain = p[0]
-        return np.diag(np.hstack((uniaxialStrain, freeStrains)))
+def makeStrainTensor_(freeStrains, p):
+    uniaxialStrain = p[0]
+    return np.diag(np.hstack((uniaxialStrain, freeStrains)))

--- a/optimism/material/test/testMaterialUniaxialSimulator.py
+++ b/optimism/material/test/testMaterialUniaxialSimulator.py
@@ -1,0 +1,40 @@
+import unittest
+
+from optimism.JaxConfig import *
+from optimism.material.MaterialUniaxialSimulator import MaterialUniaxialSimulator
+from optimism.material import LinearElastic
+from optimism.test.TestFixture import TestFixture
+
+
+class MaterialUniaxialSimulatorFixture(TestFixture):
+
+    def setUp(self):
+        self.E = 100.0
+        self.nu = 0.25
+
+        properties = {"elastic modulus": self.E,
+                      "poisson ratio": self.nu,
+                      "strain measure": "logarithmic"}
+        material = LinearElastic.create_material_model_functions(properties)
+        engineering_strain_rate = 1e-3
+
+        def strain_history(t):
+            return engineering_strain_rate*t
+
+        maxTime = 1000.0
+        
+        self.uniaxialTester = MaterialUniaxialSimulator(
+            material, strain_history, maxTime, steps=20)
+
+
+    def test_uniaxial_state_achieved(self):
+        response = self.uniaxialTester.run()
+
+        print(response.stressHistory)
+        for stress in response.stressHistory[1:]:
+            self.assertGreater(stress[0,0], 0.0) # axial stress is nonnegative
+            self.assertTrue(np.abs(np.all(stress.ravel()[1:]) < 1e-8)) # all other components near zero
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/optimism/material/test/testMaterialUniaxialSimulator.py
+++ b/optimism/material/test/testMaterialUniaxialSimulator.py
@@ -1,19 +1,19 @@
 import unittest
 
 from optimism.JaxConfig import *
-from optimism.material.MaterialUniaxialSimulator import MaterialUniaxialSimulator
+from optimism.material import MaterialUniaxialSimulator
 from optimism.material import LinearElastic
 from optimism.test.TestFixture import TestFixture
 
 
 class MaterialUniaxialSimulatorFixture(TestFixture):
 
-    def setUp(self):
-        self.E = 100.0
-        self.nu = 0.25
+    def test_uniaxial_state_achieved(self):
+        E = 100.0
+        nu = 0.25
 
-        properties = {"elastic modulus": self.E,
-                      "poisson ratio": self.nu,
+        properties = {"elastic modulus": E,
+                      "poisson ratio": nu,
                       "strain measure": "logarithmic"}
         material = LinearElastic.create_material_model_functions(properties)
         engineering_strain_rate = 1e-3
@@ -22,15 +22,8 @@ class MaterialUniaxialSimulatorFixture(TestFixture):
             return engineering_strain_rate*t
 
         maxTime = 1000.0
-        
-        self.uniaxialTester = MaterialUniaxialSimulator(
-            material, strain_history, maxTime, steps=20)
+        response = MaterialUniaxialSimulator.run(material, strain_history, maxTime, steps=20)
 
-
-    def test_uniaxial_state_achieved(self):
-        response = self.uniaxialTester.run()
-
-        print(response.stressHistory)
         for stress in response.stressHistory[1:]:
             self.assertGreater(stress[0,0], 0.0) # axial stress is nonnegative
             self.assertTrue(np.abs(np.all(stress.ravel()[1:]) < 1e-8)) # all other components near zero


### PR DESCRIPTION
This PR makes several improvements to the material uniaxial stress testing tool:

- Instead of assuming a constant strain rate, the user now passes in a function that gives the uniaxial strain as a function of time. This lets the user do things like cyclic loading, setting a desired strain rate in terms of either engineering strain or true strain, etc.
- The utility was refactored from a class to a free function. There wasn't any internal state to manage, so a class wasn't really buying us anything
- The output now contains the entire stress tensor and displacement gradient tensor at each time point, instead of only the scalar axial components. This gives the user the complete information of the problem, letting them post-process it however they like.
- Housekeeping: I updated the docstrings, updated tests that used this utility, and put in a simple unit test of the tool.