### PR TITLE
Feature/specify global jax settings in a more standard way

### DIFF
--- a/examples/arch_bc/ArchBc.py
+++ b/examples/arch_bc/ArchBc.py
@@ -1,6 +1,5 @@
 from matplotlib import pyplot as plt
 
-from optimism.JaxConfig import *
 from optimism import EquationSolver as EqSolver
 from optimism import FunctionSpace
 from optimism import Interpolants

--- a/examples/arch_bc/ArchTraction.py
+++ b/examples/arch_bc/ArchTraction.py
@@ -1,6 +1,5 @@
 from matplotlib import pyplot as plt
 
-from optimism.JaxConfig import *
 from optimism import EquationSolver as EqSolver
 from optimism import EquationSolverSubspace as SolverSubspace
 from optimism import FunctionSpace

--- a/examples/buckle_slide/Sliding.py
+++ b/examples/buckle_slide/Sliding.py
@@ -1,4 +1,6 @@
-from optimism.JaxConfig import *
+from functools import partial
+from jax import jit
+from jax import numpy as np
 
 from optimism import EquationSolver as EqSolver
 from optimism import FunctionSpace
@@ -19,9 +21,6 @@ from optimism.ConstrainedObjective import ConstrainedObjective
 from optimism.material import Neohookean
 
 from optimism.test.MeshFixture import MeshFixture
-
-import os
-os.environ['XLA_FLAGS'] = "--xla_force_host_platform_device_count=2"
 
 props = {'elastic modulus': 10.0,
          'poisson ratio': 0.3}

--- a/examples/contact_mesh_on_mesh/TwoBodyContact.py
+++ b/examples/contact_mesh_on_mesh/TwoBodyContact.py
@@ -1,8 +1,7 @@
 from matplotlib import pyplot as plt
+from jax import numpy as np
 
-from optimism.JaxConfig import *
 from optimism import EquationSolver as EqSolver
-
 from optimism import Mesh
 from optimism import Mechanics
 from optimism import FunctionSpace

--- a/examples/friction/CornerSlide.py
+++ b/examples/friction/CornerSlide.py
@@ -1,5 +1,6 @@
-from optimism.JaxConfig import *
-
+from functools import partial
+import jax
+from jax import numpy as np
 
 from optimism.material import Neohookean
 from optimism import Mechanics
@@ -112,7 +113,7 @@ class CornerSlide(MeshFixture):
         self.constraint_func = constraint_func
         
 
-    @partial(jit, static_argnums=0)
+    @partial(jax.jit, static_argnums=0)
     def create_field(self, Uu, p):
         return self.dofManager.create_field(Uu, self.get_ubcs(p))
 
@@ -150,7 +151,7 @@ class CornerSlide(MeshFixture):
         penalty = 2.5
         kappa0 = penalty * np.ones(lam0.shape)
 
-        hess_func = jit(hessian(lambda Uu,p: self.energy_func(Uu,lam0,p)))
+        hess_func = jax.jit(jax.hessian(lambda Uu,p: self.energy_func(Uu,lam0,p)))
         
         objective = ConstrainedQuasiObjective(self.energy_func,
                                               self.constraint_func,

--- a/examples/hemisphere_cap/hemisphere_plastic_disp_control.py
+++ b/examples/hemisphere_cap/hemisphere_plastic_disp_control.py
@@ -1,4 +1,6 @@
-from optimism.JaxConfig import *
+import jax
+from jax import numpy as np
+
 from optimism import EquationSolver as EqSolver
 from optimism import FunctionSpace
 from optimism import Interpolants
@@ -55,7 +57,7 @@ class TractionArch():
             strainEnergy = self.bvpFuncs.compute_strain_energy(U, internalVariables)
             return strainEnergy
         
-        self.compute_bc_reactions = jit(grad(compute_energy_from_bcs, 1))
+        self.compute_bc_reactions = jax.jit(jax.grad(compute_energy_from_bcs, 1))
         
         self.trSettings = EqSolver.get_settings(max_trust_iters=400, t1=0.4, t2=1.5, eta1=1e-8, eta2=0.2, eta3=0.8, over_iters=100)
         

--- a/examples/inverse/BuckleInverse.py
+++ b/examples/inverse/BuckleInverse.py
@@ -1,4 +1,5 @@
-from optimism.JaxConfig import *
+import jax
+from jax import numpy as np
 from jax import custom_jvp, custom_vjp
 
 from optimism import ReadMesh
@@ -197,7 +198,7 @@ class Buckle:
         outputDisp = [0,]
         outputForce = [0,]
 
-        reaction_func = jit( lambda x,p: grad(self.energy_func,1)(x,p)[0][1] )
+        reaction_func = jax.jit( lambda x,p: jax.grad(self.energy_func,1)(x,p)[0][1] )
         
         N = 1
 
@@ -254,7 +255,7 @@ class Buckle:
         opt_state = opt_init(chi)
 
         def step(step, opt_state):
-            value, grads = value_and_grad(loss)(get_params(opt_state))
+            value, grads = jax.value_and_grad(loss)(get_params(opt_state))
             opt_state = opt_update(step, grads, opt_state)
             return value, opt_state
         

--- a/examples/inverse/arch/ArchInverse.py
+++ b/examples/inverse/arch/ArchInverse.py
@@ -1,4 +1,5 @@
-from optimism.JaxConfig import *
+import jax
+from jax import numpy as np
 
 from optimism import ReadMesh
 from optimism.material import Neohookean
@@ -105,7 +106,7 @@ class Buckle(MeshFixture):
 
 
     def reaction_func(self, Uu, p):
-        return grad(self.energy_func,1)(Uu,p)[0]
+        return jax.grad(self.energy_func,1)(Uu,p)[0]
 
 
     def compute_volume(self, p):
@@ -226,7 +227,7 @@ class Buckle(MeshFixture):
         opt_state = opt_init(chi)
 
         def step(step, opt_state):
-            value, grads = value_and_grad(loss)(get_params(opt_state))
+            value, grads = jax.value_and_grad(loss)(get_params(opt_state))
             opt_state = opt_update(step, grads, opt_state)
             return value, opt_state
         

--- a/examples/material_test/MaterialTest.py
+++ b/examples/material_test/MaterialTest.py
@@ -1,8 +1,8 @@
 """Demonstrate the material testing tools."""
 
+from jax import numpy as np
 from matplotlib import pyplot as plt
 
-from optimism.JaxConfig import *
 from optimism.material import MaterialUniaxialSimulator
 from optimism.material import J2Plastic
 

--- a/examples/sharp_notch_fracture/SharpNotchFracture.py
+++ b/examples/sharp_notch_fracture/SharpNotchFracture.py
@@ -1,6 +1,7 @@
+from functools import partial
 import jax
+from jax import numpy as np
 
-from optimism.JaxConfig import *
 from optimism import AlSolver
 from optimism import BoundConstrainedSolver
 from optimism import BoundConstrainedObjective
@@ -102,7 +103,7 @@ class SharpNotchProblem:
             internalVariables = p[1]
             return self.bvpFunctions.compute_internal_energy(U, internalVariables)
         
-        self.compute_reactions = jit(grad(energy_for_rxns))
+        self.compute_reactions = jax.jit(jax.grad(energy_for_rxns))
     
 
     def plot_solution(self, U, p, lagrange, plotName):

--- a/examples/tension_axisymmetric/TensionAxisymmetric.py
+++ b/examples/tension_axisymmetric/TensionAxisymmetric.py
@@ -1,6 +1,8 @@
+from functools import partial
+import jax
+from jax import numpy as np
 from matplotlib import pyplot as plt
 
-from optimism.JaxConfig import *
 from optimism import EquationSolver as EqSolver
 from optimism import FunctionSpace
 from optimism import Interpolants
@@ -84,8 +86,8 @@ class AxisymmetricTension:
         return self.mechanicsFunctions.compute_strain_energy(U, internalVariables)
 
 
-    @partial(jit, static_argnums=0)
-    @partial(value_and_grad, argnums=2)
+    @partial(jax.jit, static_argnums=0)
+    @partial(jax.value_and_grad, argnums=2)
     def compute_reactions_from_bcs(self, Uu, Ubc, internalVariables):
         U = self.dofManager.create_field(Uu, Ubc)
         return self.mechanicsFunctions.compute_strain_energy(U, internalVariables)

--- a/examples/tension_axisymmetric/TensionAxisymmetricFracture.py
+++ b/examples/tension_axisymmetric/TensionAxisymmetricFracture.py
@@ -1,6 +1,8 @@
+from functools import partial
+import jax
+from jax import numpy as np
 from scipy.sparse import diags as sp_sparse_diags
 
-from optimism.JaxConfig import *
 from optimism import AlSolver
 from optimism import BoundConstrainedSolver
 from optimism import BoundConstrainedObjective
@@ -39,7 +41,7 @@ phaseStiffnessRelativeTolerance = 1.0/20.0
 
 def compute_row_sum_gram_matrix(fs, dummyU, dummyInternalVars):
     func = lambda u, uGrad, q, x: u
-    compute = grad(FunctionSpace.integrate_over_block, 1)
+    compute = jax.grad(FunctionSpace.integrate_over_block, 1)
     return compute(fs, dummyU, dummyInternalVars, func, fs.mesh.blocks['block_1'])
 
 
@@ -112,8 +114,8 @@ class AxisymmetricTensionFracture:
         return self.bvpFunctions.compute_internal_energy(U, internalVariables)
 
 
-    @partial(jit, static_argnums=0)
-    @partial(value_and_grad, argnums=2)
+    @partial(jax.jit, static_argnums=0)
+    @partial(jax.value_and_grad, argnums=2)
     def compute_reactions_from_bcs(self, Uu, Ubc, internalVariables):
         U = self.dofManager.create_field(Uu, Ubc)
         return self.bvpFunctions.compute_internal_energy(U, internalVariables)

--- a/examples/tension_axisymmetric/materialPointSimulation.py
+++ b/examples/tension_axisymmetric/materialPointSimulation.py
@@ -1,8 +1,7 @@
 from matplotlib import pyplot as plt
 
-from optimism.JaxConfig import *
 from optimism import TensorMath
-from optimism.phasefield import SandiaModel as MaterialModel
+from optimism.phasefield import PhaseFieldLorentzPlastic as MaterialModel
 from optimism.phasefield.MaterialPointSimulator import MaterialPointSimulator
 
 from properties import props

--- a/examples/uniaxial/Uniaxial.py
+++ b/examples/uniaxial/Uniaxial.py
@@ -1,6 +1,8 @@
+from functools import partial
+import jax
+from jax import numpy as np
 from matplotlib import pyplot as plt
 
-from optimism.JaxConfig import *
 from optimism import EquationSolver as EqSolver
 from optimism import FunctionSpace
 from optimism import Interpolants
@@ -82,8 +84,8 @@ class Uniaxial:
         return self.mechanicsFunctions.compute_strain_energy(U, internalVariables)
 
 
-    @partial(jit, static_argnums=0)
-    @partial(value_and_grad, argnums=2)
+    @partial(jax.jit, static_argnums=0)
+    @partial(jax.value_and_grad, argnums=2)
     def compute_reactions_from_bcs(self, Uu, Ubc, internalVariables):
         U = self.dofManager.create_field(Uu, Ubc)
         return self.mechanicsFunctions.compute_strain_energy(U, internalVariables)

--- a/examples/uniaxial_dynamic/UniaxialDynamic.py
+++ b/examples/uniaxial_dynamic/UniaxialDynamic.py
@@ -1,4 +1,4 @@
-#import sys
+from jax import numpy as np
 
 from optimism.JaxConfig import *
 from optimism import EquationSolver
@@ -92,13 +92,6 @@ class UniaxialDynamic:
         UuPredictor = p.dynamic_data
         UPredictor = self.create_field(UuPredictor, p)
         return self.dynamicsFunctions.compute_algorithmic_energy(U, UPredictor, internalVariables, dt)
-
-
-    # @partial(jit, static_argnums=0)
-    # @partial(value_and_grad, argnums=2)
-    # def compute_reactions_from_bcs(self, Uu, Ubc, internalVariables):
-    #     U = self.dofManager.create_field(Uu, Ubc)
-    #     return self.dynamicsFunctions.compute_output_potential_energies_and_stresses(U, internalVariables)
 
 
     def create_field(self, Uu, p):

--- a/optimism/JaxConfig.py
+++ b/optimism/JaxConfig.py
@@ -1,37 +1,9 @@
 from functools import partial
 from collections import namedtuple
-import warnings
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore")
-    import jax.numpy as np
-    from jax import grad, jacrev, jacfwd, jvp, vjp, value_and_grad, hessian, ops, lax, make_jaxpr, linearize
-    from jax import custom_jvp, custom_vjp
-    from jax import jit as jaxJit
-    from jax import vmap as jaxVmap
-    from jax.lax import while_loop
-    from jax.config import config
-
-    
-config.update("jax_enable_x64", True)
-#config.update("jax_debug_nans", True)
-
-
-jaxDebug=False
-
-if jaxDebug:
-    def jit(f,static_argnums=None):
-        return f
-    
-    vmap = jaxVmap
-
-    def while_loop(cond_fun, body_fun, init_val):
-        val = init_val
-        while cond_fun(val):
-            val = body_fun(val)
-        return val
-else:
-    jit = jaxJit
-    vmap = jaxVmap
+import jax.numpy as np
+from jax import grad, jacrev, jacfwd, jvp, vjp, vmap, value_and_grad, hessian, ops, lax, make_jaxpr, linearize, jit
+from jax import custom_jvp, custom_vjp
+from jax.lax import while_loop
 
 
 def if_then_else(cond, val1, val2):

--- a/optimism/__init__.py
+++ b/optimism/__init__.py
@@ -1,0 +1,15 @@
+from jax import config
+
+# force double precision floating point arithmetic
+# this is deprecated in jax, we'll have to find another way soon.
+config.update("jax_enable_x64", True)
+
+# silence warnings about no gpu/tpu
+config.update("jax_platforms", "cpu")
+
+# debugging options
+#config.update("jax_debug_nans", True)
+#config.update("jax_debug_infs", True)
+#config.update("jax_disable_jit", True)
+
+del config

--- a/optimism/test/testJaxConfig.py
+++ b/optimism/test/testJaxConfig.py
@@ -1,7 +1,26 @@
+import unittest
+
 from optimism.JaxConfig import *
-from optimism.test.TestFixture import *
+from optimism.test import TestFixture
+
+from jax import config
 
 
-class TestDebugIsOff(TestFixture):
-    def test_debug_if_off(self):
-        self.assertTrue(not jaxDebug)
+class TestJaxConfiguration(TestFixture.TestFixture):
+
+    def test_double_precision_mode_is_on(self):
+        a = np.array([1.0])
+        self.assertTrue(a.dtype == np.float64)
+
+    def test_debug_nans_is_off(self):
+        np.log(-1.0)
+
+    def test_debug_infs_is_off(self):
+        a = np.array([1.0])
+        a/0
+
+    def test_jit_is_enabled(self):
+        self.assertFalse(config.jax_disable_jit)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/optimism/test/testJaxConfig.py
+++ b/optimism/test/testJaxConfig.py
@@ -13,11 +13,17 @@ class TestJaxConfiguration(TestFixture.TestFixture):
         self.assertTrue(a.dtype == np.float64)
 
     def test_debug_nans_is_off(self):
-        np.log(-1.0)
+        try:
+            np.log(-1.0)
+        except FloatingPointError:
+            self.fail("Floating point exception raised. Check to see if 'jax_debug_nans' has been left activated from a debugging session.")
 
     def test_debug_infs_is_off(self):
-        a = np.array([1.0])
-        a/0
+        try:
+            a = np.array([1.0])
+            a/0
+        except FloatingPointError:
+            self.fail("Floating point exception raised. Check to see if 'jax_debug_infs' has been left activated from a debugging session.")
 
     def test_jit_is_enabled(self):
         self.assertFalse(config.jax_disable_jit)


### PR DESCRIPTION
The only code change to the library is to move the specification of global Jax settings to the package `__init__.py` file. The old paradigm was to put these settings in `JaxConfig.py`, and ask everyone, even external API users, to `import *` from this module. This is bad style, since it pulls a bunch of symbols into the global namespace implicitly, making code harder to read. This also made name collisions more likely. The `__init__.py` file is guaranteed to be executed first when the package is imported, so it accomplishes the same thing in a standard idiom.

The main reason for the global settings is to force Jax to use double precision floating point arithmetic. I also added another setting to silence a warning that is useless to us (that no GPU is found and that the code is executing on CPU). We haven't implemented GPU operations anyway.

The PR also adds tests to make sure the intended settings are indeed applied, and removes the ugly `from optimism.JaxConfig import *` statements from all of the examples.