### PR TITLE
Avoid superfluous copy of residual vector when applying preconditioner

### DIFF
--- a/optimism/SparseCholesky.py
+++ b/optimism/SparseCholesky.py
@@ -51,7 +51,7 @@ class SparseCholesky:
         
     def apply(self, b):
         if type(b) == type(np.array([])):
-            b = onp.array(b)
+            b = onp.array(b, copy=False)
         return self.Precond(b)
 
         


### PR DESCRIPTION
In order for the sparse Cholesky preconditioner to work correctly, 
the residual vector is changed from a jax-numpy array to a standard
numpy array before the preconditioner is applied. 

In this PR, numpy is instructed to avoid copying the 
residual data and instead re-use the buffer of the jax-numpy
array. This should avoid overhead, especially for large vectors.

Fixes #29 