### PR TITLE
Fix bug that broke use of internal variables with multi-materials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ __pycache__/
 
 # typical name for python virtual environment
 venv/
+
+# IDE files
+.idea/

--- a/optimism/Mechanics.py
+++ b/optimism/Mechanics.py
@@ -142,7 +142,7 @@ def _compute_updated_internal_variables_multi_block(functionSpace, U, states, bl
         dgQuadPointRavel = blockDispGrads.reshape(blockDispGrads.shape[0]*blockDispGrads.shape[1],*blockDispGrads.shape[2:])
         stQuadPointRavel = blockStates.reshape(blockStates.shape[0]*blockStates.shape[1],-1)
         blockStatesNew = vmap(compute_state_new)(dgQuadPointRavel, stQuadPointRavel).reshape(blockStates.shape)        
-        statesNew = blockStatesNew.at[elemIds].set(blockStatesNew)
+        statesNew = statesNew.at[elemIds, :, :blockStatesNew.shape[2]].set(blockStatesNew)
         
 
     return statesNew
@@ -169,7 +169,7 @@ def _compute_initial_state_multi_block(fs, blockModels):
     for blockKey in blockModels:
         elemIds = fs.mesh.blocks[blockKey]
         blockInitialState = blockModels[blockKey].compute_initial_state( (elemIds.size, numQuadPoints, 1) )
-        initialState = initialState.at[elemIds].set(blockInitialState)
+        initialState = initialState.at[elemIds, :, :blockInitialState.shape[2]].set(blockInitialState)
 
     return initialState
 

--- a/optimism/test/testMechanics.py
+++ b/optimism/test/testMechanics.py
@@ -1,0 +1,57 @@
+import jax.numpy as np
+import unittest
+from unittest import mock
+
+from optimism import FunctionSpace
+from optimism import QuadratureRule
+from optimism.test import MeshFixture
+from optimism import Mechanics
+from optimism import Mesh
+from optimism.material import J2Plastic, Neohookean
+
+class MechanicsFunctionsFixture(MeshFixture.MeshFixture):
+
+    def setUp(self):
+        self.Nx = 3
+        self.Ny = 3
+        xRange = [0.0, 1.0]
+        yRange = [0.0, 1.0]
+
+        self.targetDispGrad = np.array([[0.1, -0.2], [0.4, -0.1]])
+
+        mesh, self.U = self.create_mesh_and_disp(self.Nx, self.Ny, xRange, yRange,
+                                                 lambda x: self.targetDispGrad.dot(x))
+        blocks = {'block0': np.array([0, 1, 2, 3]),
+                  'block1': np.array([4, 5, 6, 7])}
+        self.mesh = Mesh.mesh_with_blocks(mesh, blocks)
+        self.quadRule = QuadratureRule.create_quadrature_rule_on_triangle(2)
+        self.fs = FunctionSpace.construct_function_space(self.mesh, self.quadRule)
+
+        props = {'elastic modulus': 1,
+                 'poisson ratio': 0.25,
+                 'yield strength': 0.1,
+                 'hardening model': 'linear',
+                 'hardening modulus': 0.1}
+
+        materialModel0 = Neohookean.create_material_model_functions(props)
+        materialModel1 = J2Plastic.create_material_model_functions(props)
+        self.blockModels = {'block0': materialModel0, 'block1': materialModel1}
+
+
+    def test_internal_variables_initialization_on_multi_block(self):
+        nQuadPoints = QuadratureRule.len(self.quadRule)
+        internals = Mechanics._compute_initial_state_multi_block(self.fs, self.blockModels)
+        self.assertEqual(internals.shape, (Mesh.num_elements(self.mesh), nQuadPoints, 10))
+        self.assertArrayEqual(internals[0, 0], np.zeros(J2Plastic.NUM_STATE_VARS))
+        self.assertArrayEqual(internals[4, 0], np.array([0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]))
+
+    def test_internal_variables_update_on_multi_block(self):
+        nQuadPoints = QuadratureRule.len(self.quadRule)
+        internals = Mechanics._compute_initial_state_multi_block(self.fs, self.blockModels)
+        internalsNew = Mechanics._compute_updated_internal_variables_multi_block(self.fs, self.U, internals, self.blockModels, Mechanics.plane_strain_gradient_transformation)
+        self.assertEqual(internals.shape, internalsNew.shape)
+        self.assertGreater(internalsNew[4,0,J2Plastic.EQPS], 0.05)
+
+    if __name__ == "__main__":
+        unittest.main()
+


### PR DESCRIPTION
I didn't check in tests when I implemented the use of internal variables in the multi-material case. There were several bugs that caused incorrect behavior. This PR fixes those bugs and adds some tests to verify the fixes.

Fixes #32.