### PR TITLE
Make dynamics more like statics

### DIFF
--- a/examples/uniaxial_dynamic/plotUniaxialDynamic.py
+++ b/examples/uniaxial_dynamic/plotUniaxialDynamic.py
@@ -14,10 +14,12 @@ fig, axs = plt.subplots(2, figsize=(12,10))
 axs[0].plot(t, u, marker='o', linestyle='--')
 axs[0].set(xlabel='time', ylabel='tip displacement')
 
-print(ke+se)
-axs[1].plot(t, ke + se, marker='o')
+axs[1].plot(t, ke, 'k-', label='KE')
+axs[1].plot(t, se, 'r-', label='SE')
+axs[1].plot(t, ke + se, '--', label='TOTAL')
 axs[1].set(xlabel='time', ylabel='energy')
 axs[1].set_ylim(0.0, None)
+axs[1].legend()
 
 plt.tight_layout()
 

--- a/optimism/Mechanics.py
+++ b/optimism/Mechanics.py
@@ -24,6 +24,7 @@ DynamicsFunctions = namedtuple('DynamicsFunctions',
                                 'compute_output_kinetic_energy',
                                 'compute_output_strain_energy',
                                 'compute_initial_state',
+                                'compute_element_masses', # not used for time integration, provided for convenience (spectral analysis, eg)
                                 'predict',
                                 'correct'])
 
@@ -77,14 +78,6 @@ def _compute_element_stiffnesses(U, internals, functionSpace, compute_energy_den
     fs = functionSpace
     return f(U, fs.mesh.coords, internals, fs.mesh.conns, fs.shapes, fs.shapeGrads, fs.vols,
              L, modify_element_gradient)
-
-
-def sparse_matrix_from_energy_density(U, internals, functionSpace, dofManager, compute_energy_density):
-     elementHessians = compute_element_stiffnesses(U, internals, functionSpace, compute_energy_density)
-     K = SparseMatrixAssembler.assemble_sparse_stiffness_matrix(elementHessians,
-                                                                functionSpace.conns,
-                                                                dofManager)
-     return K
 
 
 def _compute_strain_energy(functionSpace, UField, stateField,
@@ -301,36 +294,42 @@ def create_mechanics_functions(functionSpace, mode2D, materialModel, pressurePro
     return MechanicsFunctions(compute_strain_energy, jit(compute_updated_internal_variables), jit(compute_element_stiffnesses), jit(compute_output_energy_densities_and_stresses), compute_initial_state)
 
 
-def compute_element_mass_matrix(density, elemShapes, elemVols):
-    m = elemShapes.T@np.diag(density*elemVols)@elemShapes
-    M = np.zeros((m.shape[0],2,m.shape[0],2))
-    for i in range(2):
-        M = M.at[:,i,:,i].set(m)
-    return M
-
-    
-def compute_element_masses(density, mesh):
-    elementOrder = mesh.masterElement.degree
-    quadRule = QuadratureRule.create_quadrature_rule_on_triangle(degree=2*(elementOrder))
-    fs = FunctionSpace.construct_function_space(mesh, quadRule)
-    return vmap(compute_element_mass_matrix, (None,0,0))(density, fs.shapes, fs.vols)
+def _compute_kinetic_energy(functionSpace, V, internals, density):
+    def lagrangian_density(V, gradV, Q, X):
+        return kinetic_energy_density(V, density)
+    return FunctionSpace.integrate_over_block(functionSpace, V, internals, lagrangian_density, slice(None))
 
 
-def compute_element_kinetic_energy(V, elementMass, elementConn):
-    elementVs = V[elementConn,:].ravel()
-    rowSz = elementMass.shape[0]*elementMass.shape[1]
-    return 0.5*elementVs@elementMass.reshape(rowSz,rowSz)@elementVs
+def _compute_element_masses(functionSpace, U, internals, density, modify_element_gradient):
+    def lagrangian_density(V, gradV, Q, X):
+        return kinetic_energy_density(V, density)
+    f = vmap(compute_element_stiffness_from_global_fields, (None, None, 0 ,0 ,0 ,0 ,0, None, None))
+    fs = functionSpace
+    return f(U, fs.mesh.coords, internals, fs.mesh.conns, fs.shapes, fs.shapeGrads, fs.vols,
+             lagrangian_density, modify_element_gradient)
 
 
-def compute_kinetic_energy(V, elementMasses, elementConns):
-    def f(carry, x):
-        elemConn, elemMass = x
-        elemT = compute_element_kinetic_energy(V, elemMass, elemConn)
-        carry += elemT
-        return carry, elemT
-    
-    T, elemKineticEnergies = lax.scan(f, 0.0, (elementConns,elementMasses))
-    return T
+def kinetic_energy_density(V, density):
+    return 0.5*density*np.dot(V, V)
+
+
+def compute_newmark_lagrangian(functionSpace, U, UPredicted, internals, density, dt, newmarkBeta, strain_energy_density, modify_element_gradient):
+    def lagrangian_density(u, gradu, q, X):
+        vAlgorithmic = (u - UPredicted)/dt
+        return kinetic_energy_density(vAlgorithmic, density)/newmarkBeta + strain_energy_density(gradu, q)
+    return FunctionSpace.integrate_over_block(functionSpace, U, internals, lagrangian_density,
+                                              slice(None), modify_element_gradient)
+
+
+def _compute_newmark_element_hessians(functionSpace, U, UPredicted, internals, density, dt, newmarkBeta, strain_energy_density, modify_element_gradient):
+    def lagrangian_density(u, gradu, q, X):
+        vAlgorithmic = (u - UPredicted)/dt
+        return kinetic_energy_density(vAlgorithmic, density)/newmarkBeta + strain_energy_density(gradu, q)
+    f =  vmap(compute_element_stiffness_from_global_fields,
+              (None, None, 0, 0, 0, 0, 0, None, None))
+    fs = functionSpace
+    return f(U, fs.mesh.coords, internals, fs.mesh.conns, fs.shapes, fs.shapeGrads, fs.vols,
+             lagrangian_density, modify_element_gradient)
 
 
 def parse_2D_to_3D_gradient_transformation(mode2D):
@@ -342,12 +341,6 @@ def parse_2D_to_3D_gradient_transformation(mode2D):
         raise ValueError("Unrecognized value for mode2D")
     
     return grad_2D_to_3D
-
-
-def compute_algorithmic_kinetic_energy(U, UPredicted, elementMasses, elementConns,
-                                       dt, newmarkBeta):
-    V = (U - UPredicted)/dt
-    return compute_kinetic_energy(V, elementMasses, elementConns)/newmarkBeta
 
 
 def define_pressure_projection_gradient_tranformation(pressureProjectionDegree, modify_element_gradient):
@@ -365,31 +358,26 @@ def define_pressure_projection_gradient_tranformation(pressureProjectionDegree, 
     return modify_element_gradient
 
 
-def create_dynamics_functions(functionSpace, mode2D, materialModel, newmarkParameters, elementMasses, pressureProjectionDegree=None):
+def create_dynamics_functions(functionSpace, mode2D, materialModel, newmarkParameters, pressureProjectionDegree=None):
     fs = functionSpace
 
     modify_element_gradient = parse_2D_to_3D_gradient_transformation(mode2D)
     modify_element_gradient = define_pressure_projection_gradient_tranformation(
         pressureProjectionDegree, modify_element_gradient)
-  
+
     def compute_algorithmic_energy(U, UPredicted, stateVariables, dt):
-        PE = _compute_strain_energy(fs, U, stateVariables, materialModel.compute_energy_density, modify_element_gradient)
-        KE = compute_algorithmic_kinetic_energy(U, UPredicted, elementMasses, fs.mesh.conns,
-                                                dt, newmarkParameters.beta)
-        return PE + KE
+        return compute_newmark_lagrangian(functionSpace, U, UPredicted, stateVariables,
+                                          materialModel.density, dt, newmarkParameters.beta,
+                                          materialModel.compute_energy_density,
+                                          modify_element_gradient)
     
     def compute_updated_internal_variables(U, stateVariables):
         return _compute_updated_internal_variables(fs, U, stateVariables, materialModel.compute_state_new, modify_element_gradient)
     
-    def compute_element_hessians(U, stateVariables, dt):
-        elementStiffnesses = _compute_element_stiffnesses(U, stateVariables, fs, materialModel.compute_energy_density, modify_element_gradient)
-        return elementStiffnesses + elementMasses/(newmarkParameters.beta*dt*dt)
-
-    def compute_output_kinetic_energy(V):
-        return compute_kinetic_energy(V, elementMasses, fs.mesh.conns)
-
-    def compute_output_strain_energy(U, stateVariables):
-        return _compute_strain_energy(functionSpace, U, stateVariables, materialModel.compute_energy_density, modify_element_gradient)
+    def compute_element_hessians(U, UPredicted, stateVariables, dt):
+        return _compute_newmark_element_hessians(
+            functionSpace, U, UPredicted, stateVariables, materialModel.density, dt, 
+            newmarkParameters.beta, materialModel.compute_energy_density, modify_element_gradient)
 
     compute_output_energy_density = materialModel.compute_output_energy_density
     output_lagrangian = strain_energy_density_to_lagrangian_density(compute_output_energy_density)
@@ -397,8 +385,20 @@ def create_dynamics_functions(functionSpace, mode2D, materialModel, newmarkParam
     def compute_output_potential_densities_and_stresses(U, stateVariables):
         return FunctionSpace.evaluate_on_block(fs, U, stateVariables, output_constitutive, slice(None), modify_element_gradient)
 
+    def compute_kinetic_energy(V):
+        stateVariables = np.zeros((Mesh.num_elements(fs.mesh), QuadratureRule.len(fs.quadratureRule)))
+        return _compute_kinetic_energy(functionSpace, V, stateVariables, materialModel.density)
+
+    def compute_output_strain_energy(U, stateVariables):
+        return _compute_strain_energy(functionSpace, U, stateVariables, materialModel.compute_energy_density, modify_element_gradient)
+
     def compute_initial_state():
         return materialModel.compute_initial_state((Mesh.num_elements(fs.mesh), QuadratureRule.len(fs.quadratureRule), 1))
+
+    def compute_element_masses():
+        V = np.zeros_like(fs.mesh.coords)
+        stateVariables = np.zeros((Mesh.num_elements(fs.mesh), QuadratureRule.len(fs.quadratureRule)))
+        return _compute_element_masses(functionSpace, V, stateVariables, materialModel.density, modify_element_gradient)
 
     def predict(U, V, A, dt):
         U += dt*V + 0.5*dt*dt*(1.0 - 2.0*newmarkParameters.beta)*A
@@ -414,8 +414,9 @@ def create_dynamics_functions(functionSpace, mode2D, materialModel, newmarkParam
                              jit(compute_updated_internal_variables),
                              jit(compute_element_hessians),
                              jit(compute_output_potential_densities_and_stresses),
-                             jit(compute_output_kinetic_energy),
+                             jit(compute_kinetic_energy),
                              jit(compute_output_strain_energy),
                              compute_initial_state,
+                             jit(compute_element_masses),
                              jit(predict),
                              jit(correct))

--- a/optimism/material/J2Plastic.py
+++ b/optimism/material/J2Plastic.py
@@ -44,7 +44,7 @@ def create_material_model_functions(properties):
             finiteDeformations = False
             sethHill = True
         else:
-            raise valueError('Unknown value specified for kinematics in J2Plastic')
+            raise ValueError('Unknown value specified for kinematics in J2Plastic')
         
     if finiteDeformations:
         compute_elastic_strain = compute_elastic_logarithmic_strain
@@ -78,11 +78,14 @@ def create_material_model_functions(properties):
     def output_energy_density_function(dispGrad, state):
         elasticTrialStrain = compute_elastic_strain(dispGrad, state)
         return energy_density_generic(elasticTrialStrain, state, props, hardeningModel, doUpdate=False)
-    
+
+    density = properties.get('density')
+
     return MaterialModel(energy_density_function,
                          output_energy_density_function,
                          compute_initial_state,
-                         compute_state_new_function)
+                         compute_state_new_function,
+                         density)
 
 
 def make_properties(E, nu, Y0):

--- a/optimism/material/LinearElastic.py
+++ b/optimism/material/LinearElastic.py
@@ -25,7 +25,7 @@ def create_material_model_functions(properties):
     elif strainMeasure == 'logarithmic':
         _strain = log_strain
     else:
-        raise valueError('Unrecognized strain measure')
+        raise ValueError('Unrecognized strain measure')
     
     def strain_energy(dispGrad, internalVars):
         strain = _strain(dispGrad)
@@ -34,11 +34,14 @@ def create_material_model_functions(properties):
     def compute_state_new(dispGrad, internalVars):
         strain = _strain(dispGrad)
         return _compute_state_new(strain, internalVars, props)
-    
+
+    density = properties.get('density')
+
     return MaterialModel(compute_energy_density = strain_energy,
                          compute_output_energy_density = strain_energy,
                          compute_initial_state = make_initial_state,
-                         compute_state_new = compute_state_new)
+                         compute_state_new = compute_state_new,
+                         density = density)
 
 
 def _make_properties(E, nu):

--- a/optimism/material/MaterialModel.py
+++ b/optimism/material/MaterialModel.py
@@ -5,4 +5,4 @@ MatProps = namedtuple('MatProps', ['props','num_props','num_states'])
 
 MaterialModel = namedtuple('MaterialModel',
                            ['compute_energy_density', 'compute_output_energy_density',
-                            'compute_initial_state', 'compute_state_new'])
+                            'compute_initial_state', 'compute_state_new', 'density'], defaults=(0.0,))

--- a/optimism/material/Neohookean.py
+++ b/optimism/material/Neohookean.py
@@ -26,10 +26,13 @@ def create_material_model_functions(properties):
     def compute_state_new(dispGrad, internalVars):
         return _compute_state_new(dispGrad, internalVars, props)
     
+    density = properties.get('density')
+    
     return MaterialModel(strain_energy,
                          strain_energy,
                          make_initial_state,
-                         compute_state_new)
+                         compute_state_new,
+                         density)
 
 
 def _make_properties(E, nu):


### PR DESCRIPTION
The dynamics module was done in a rush at the end of the LDRD. It did not mirror the implementation of statics as well as it should. This PR fixes the two main divergences:

1. The constructors for the physics modules. The quasi-static physics module was constructed with its factory function like this:  
    ```python
    create_mechanics_functions(functionSpace, mode2D, materialModel, pressureProjectionDegree=None)
    ```
    This seems like the right information to set up the physics: the discrete function space (which includes the mesh), how the 2D problem should be treated (plane strain or axisymmetric are currently supported), the material model, and optionally, a lower projection of the pressure to avoid locking in certain problems. All of the operations you would want to solve the problem are provided by this module: computing the potential, residuals, assembly of element stiffness matrices for preconditioning, etc.  
    The dynamics module, on the other hand, required you to manually compute the element mass matrices in order to instantiate it. It looked like this:
    ```python
    create_dynamics_functions(functionSpace, mode2D, materialModel, newmarkParameters, elementMasses, pressureProjectionDegree=None)
    ```
    Assembling the mass matrices is the kind of thing the dynamics module should be doing *for* you, if it's needed, not demanded as a prerequisite. This PR eliminates this argument so that the signature is now:
    ```python
    create_dynamics_functions(functionSpace, mode2D, materialModel, newmarkParameters, pressureProjectionDegree=None)
    ```
    which mirrors the statics case nicely, adding only the Newmark time integration parameters (which is an appropriate difference with statics).
2. The actual computation in the dynamics module didn't fit the design pattern, either. We want the code to operate on scalar-valued functionals, reflecting the variational nature of the problems. This implies that it takes in a field and computes an integral, and eventually finds the field that minimizes the functional. For the dynamics, the functional wasn't implemented as an integral. The kinetic energy contribution was assembled discretely, using matrix-vector operations directly, like this:  
    ```python
    def compute_element_kinetic_energy(V, elementMass, elementConn):
        elementVs = V[elementConn,:].ravel()
        rowSz = elementMass.shape[0]*elementMass.shape[1]
        return 0.5*elementVs@elementMass.reshape(rowSz,rowSz)@elementVs
    ```
    Now these terms are assembled with integrals using the integration routines in `FunctionSpace`:
    ```python
    def compute_newmark_lagrangian(functionSpace, U, UPredicted, internals, density, dt, newmarkBeta, strain_energy_density, modify_element_gradient):
        def lagrangian_density(W, gradW, Q, X):
            return kinetic_energy_density(W, density)
        KE = FunctionSpace.integrate_over_block(functionSpace, U - UPredicted, internals, lagrangian_density,
                                                slice(None), modify_element_gradient) / (newmarkBeta*dt**2)

        lagrangian_density = strain_energy_density_to_lagrangian_density(strain_energy_density)
        SE = FunctionSpace.integrate_over_block(functionSpace, U, internals, lagrangian_density,
                                                slice(None), modify_element_gradient)
        return SE + KE
    ```
    Not only much cleaner, but now there are opportunuties to unify more functions between statics and dynamics.

Additionally, I updated the existing tests with these changes, and also the lone app that was using dynamics.

TODO: there should be a patch test covering dynamics. Right now, the tests only check the integration of rigid body modes. The test suite should be sensitive to errors introduced in deformable body dynamics. I need to do more work to figure out exactly how that should look analytically first. I've opened an issue to keep track of this.