### PR TITLE
Make Neo-Hookean consistent with small strains

### DIFF
--- a/optimism/material/Neohookean.py
+++ b/optimism/material/Neohookean.py
@@ -2,10 +2,11 @@ from optimism.JaxConfig import *
 from optimism.material.MaterialModel import MaterialModel
 
 # props
-PROPS_E     = 0
-PROPS_NU    = 1
-PROPS_MU    = 2
-PROPS_KAPPA = 3
+PROPS_E      = 0
+PROPS_NU     = 1
+PROPS_MU     = 2
+PROPS_KAPPA  = 3
+PROPS_LAMBDA = 4
 
 
 def create_material_model_functions(properties):
@@ -38,20 +39,22 @@ def create_material_model_functions(properties):
 def _make_properties(E, nu):
     mu = 0.5*E/(1.0 + nu)
     kappa = E / 3.0 / (1.0 - 2.0*nu)
-    return np.array([E, nu, mu, kappa])
+    lamda = E*nu/(1 + nu)/(1 - 2*nu)
+    return np.array([E, nu, mu, kappa, lamda])
 
 
 def _neohookean_3D_energy_density(dispGrad, internalVariables, props):
     F = dispGrad + np.eye(3)
     J = np.linalg.det(F)
-    
-    C = F.T@F
-    I1 = np.trace(C)
 
+    #Wvol = 0.125*props[PROPS_LAMBDA]*(J - 1.0/J)**2
+    Wvol = 0.5*props[PROPS_LAMBDA]*np.log(J)**2
+
+    # I1m3 = tr(F.T@F) - 3, rewritten in terms of dispGrad
+    I1m3 = 2.0*np.trace(dispGrad) + np.tensordot(dispGrad, dispGrad)
     C1 = 0.5*props[PROPS_MU]
-    D1 = 0.125*props[PROPS_KAPPA]
 
-    return C1*(I1-3.-2.*np.log(J)) + D1*(J - 1.0/J)**2
+    return C1*(I1m3-2.*np.log(J)) + Wvol
 
 
 def _adagio_neohookean(dispGrad, internalVariables, props):


### PR DESCRIPTION
For the "coupled" version of the Neo-Hookean model, the material parameters were misleading. The property labeled as the bulk modulus was used in a place where it really acted as the Lame's lambda parameter. The model wasn't wrong per se, but it would not match infinitesimal strains in the expected way.

This commit adds the Lame lambda parameter and switches to the standard usage.