### PR TITLE
Simplify plasticity

### DIFF
--- a/optimism/Mechanics.py
+++ b/optimism/Mechanics.py
@@ -225,7 +225,7 @@ def create_multi_block_mechanics_functions(functionSpace, mode2D, materialModels
         energy_densities = np.zeros((Mesh.num_elements(fs.mesh), QuadratureRule.len(fs.quadratureRule)))
         stresses = np.zeros((Mesh.num_elements(fs.mesh), QuadratureRule.len(fs.quadratureRule), 3, 3))
         for blockKey in materialModels:
-            compute_output_energy_density = materialModels[blockKey].compute_output_energy_density
+            compute_output_energy_density = materialModels[blockKey].compute_energy_density
             output_lagrangian = strain_energy_density_to_lagrangian_density(compute_output_energy_density)
             output_constitutive = value_and_grad(output_lagrangian, 1)
             elemIds = fs.mesh.blocks[blockKey]
@@ -277,10 +277,8 @@ def create_mechanics_functions(functionSpace, mode2D, materialModel, pressurePro
     def compute_element_stiffnesses(U, stateVariables):
         return _compute_element_stiffnesses(U, stateVariables, fs, materialModel.compute_energy_density, modify_element_gradient)
 
-    
-    compute_output_energy_density = materialModel.compute_output_energy_density
 
-    output_lagrangian = strain_energy_density_to_lagrangian_density(compute_output_energy_density)
+    output_lagrangian = strain_energy_density_to_lagrangian_density(materialModel.compute_energy_density)
     output_constitutive = value_and_grad(output_lagrangian, 1)
 
     
@@ -388,8 +386,7 @@ def create_dynamics_functions(functionSpace, mode2D, materialModel, newmarkParam
             functionSpace, U, UPredicted, stateVariables, materialModel.density, dt, 
             newmarkParameters.beta, materialModel.compute_energy_density, modify_element_gradient)
 
-    compute_output_energy_density = materialModel.compute_output_energy_density
-    output_lagrangian = strain_energy_density_to_lagrangian_density(compute_output_energy_density)
+    output_lagrangian = strain_energy_density_to_lagrangian_density(materialModel.compute_energy_density)
     output_constitutive = value_and_grad(output_lagrangian, 1)
     def compute_output_potential_densities_and_stresses(U, stateVariables):
         return FunctionSpace.evaluate_on_block(fs, U, stateVariables, output_constitutive, slice(None), modify_element_gradient=modify_element_gradient)

--- a/optimism/ScalarRootFind.py
+++ b/optimism/ScalarRootFind.py
@@ -8,7 +8,7 @@ SolutionInfo = namedtuple('SolutionInfo', ['converged', 'iterations', 'function_
 Settings = namedtuple('Settings', ['max_iters', 'x_tol', 'r_tol'])
 
 
-def get_settings(max_iters=50, x_tol=1e-13, r_tol=1e-10):
+def get_settings(max_iters=50, x_tol=1e-13, r_tol=0):
     """Get numerical settings for the root finder.
 
     Parameters

--- a/optimism/ScalarRootFind.py
+++ b/optimism/ScalarRootFind.py
@@ -1,13 +1,14 @@
-from optimism.JaxConfig import *
+from collections import namedtuple
 
-from jax.lax import custom_root
+import jax
+import jax.numpy as np
 
 SolutionInfo = namedtuple('SolutionInfo', ['converged', 'iterations', 'function_calls'])
 
-Settings = namedtuple('Settings', ['max_iters', 'x_tol'])
+Settings = namedtuple('Settings', ['max_iters', 'x_tol', 'r_tol'])
 
 
-def get_settings(max_iters=50, x_tol=1e-13):
+def get_settings(max_iters=50, x_tol=1e-13, r_tol=1e-10):
     """Get numerical settings for the root finder.
 
     Parameters
@@ -18,12 +19,14 @@ def get_settings(max_iters=50, x_tol=1e-13):
         Tolerance on independent variable for convergence. The root finder will
         terminate when the independent variable changes by less than `x_tol` in
         an iteration.
+    r_tol : real
+        Tolerance on absolute value of residual for convergence.
 
     Returns
     =======
     settings : A Settings object, which can be used in `find_root`.
     """
-    return Settings(max_iters, x_tol)
+    return Settings(max_iters, x_tol, r_tol)
 
 
 def find_root(f, x0, bracket, settings):
@@ -54,8 +57,8 @@ def find_root(f, x0, bracket, settings):
         Argument of f such that f(x) = 0 (within provided tolerance). If the
         root is not bracketed, `nan` is returned.
     """
-    return custom_root(f, x0, lambda F, X0: rtsafe_(F, X0, bracket, settings),
-                       lambda g, y: y/g(1.0))
+    return jax.lax.custom_root(f, x0, lambda F, X0: rtsafe_(F, X0, bracket, settings),
+                               lambda g, y: y/g(1.0))
 
 
 def rtsafe_(f, x0, bracket, settings):
@@ -66,7 +69,7 @@ def rtsafe_(f, x0, bracket, settings):
     max_iters = settings.max_iters
     x_tol = settings.x_tol
 
-    f_and_fprime = value_and_grad(f)
+    f_and_fprime = jax.value_and_grad(f)
 
     converged = False
 
@@ -88,10 +91,10 @@ def rtsafe_(f, x0, bracket, settings):
     converged = np.where(rightBracketIsSolution, True, converged)
 
     # ORIENT THE SEARCH SO THAT F(XL) < 0.
-    xl, xh = lax.cond(fl < 0,
-                      lambda b: (b[0], b[1]),
-                      lambda b: (b[1], b[0]),
-                      bracket)
+    xl, xh = jax.lax.cond(fl < 0,
+                          lambda b: (b[0], b[1]),
+                          lambda b: (b[1], b[0]),
+                          bracket)
 
     # INITIALIZE THE GUESS FOR THE ROOT, THE ''STEP SIZE
     # BEFORE LAST'', AND THE LAST STEP
@@ -113,25 +116,25 @@ def rtsafe_(f, x0, bracket, settings):
         newtonOutOfRange = ((root - xh)*DF - F) * ((root - xl)*DF - F) > 0
         newtonDecreasingSlowly = np.abs(2.*F) > np.abs(dxOld*DF)
         dxOld = dx
-        root, dx, converged = lax.cond(newtonOutOfRange | newtonDecreasingSlowly,
-                                       bisection_step,
-                                       newton_step,
-                                       root, xl, xh, DF, F)
+        root, dx, converged = jax.lax.cond(newtonOutOfRange | newtonDecreasingSlowly,
+                                           bisection_step,
+                                           newton_step,
+                                           root, xl, xh, DF, F)
 
         F, DF = f_and_fprime(root)
 
         # MAINTAIN THE BRACKET ON THE ROOT
-        xl,xh = lax.cond(F < 0,
-                         lambda rt, lo, hi: (rt, hi),
-                         lambda rt, lo, hi: (lo, rt),
-                         root, xl, xh)
+        xl,xh = jax.lax.cond(F < 0,
+                             lambda rt, lo, hi: (rt, hi),
+                             lambda rt, lo, hi: (lo, rt),
+                             root, xl, xh)
         i += 1
         converged = converged | (np.abs(dx) < x_tol) # absolute tolerance
         return root, dx, dxOld, F, DF, xl, xh, converged, i
 
-    x, _, _, _, _, _, _, converged, iters = while_loop(cond,
-                                                       loop_body,
-                                                       (x0, dx, dxOld, F, DF, xl, xh, converged, 0))
+    x, _, _, _, _, _, _, converged, iters = jax.lax.while_loop(cond,
+                                                               loop_body,
+                                                               (x0, dx, dxOld, F, DF, xl, xh, converged, 0))
 
     x = np.where(converged, x, np.nan)
     

--- a/optimism/material/Hardening.py
+++ b/optimism/material/Hardening.py
@@ -1,5 +1,7 @@
 from collections import namedtuple
-from optimism.JaxConfig import *
+
+import jax
+import jax.numpy as np
 
 HardeningModel = namedtuple('HardeningModel', ['compute_hardening_energy_density', 'compute_flow_stress'])
 
@@ -28,26 +30,20 @@ def create_hardening_model(properties):
             return power_law(eqps, Y0, n, eps0)
 
     else:
-        raise valueError('Unknown hardening model specified')
+        raise ValueError('Unknown hardening model specified')
 
-    return HardeningModel(hardening_energy_density, grad(hardening_energy_density))
+    return HardeningModel(hardening_energy_density, jax.grad(hardening_energy_density))
 
 
 def linear(eqps, Y0, H):
-    return np.where(eqps >= 0.0,
-                    Y0*eqps + 0.5*H*eqps**2,
-                    np.inf)
+    return Y0*eqps + 0.5*H*eqps**2
 
 
 def voce(eqps, Y0, Ysat, eps0):
-    return np.where(eqps >= 0.0,
-                    Ysat*eqps + (Ysat - Y0)*eps0*(np.expm1(-eqps/eps0)),
-                    np.inf)
+    return Ysat*eqps + (Ysat - Y0)*eps0*(np.expm1(-eqps/eps0))
 
 
 def power_law(eqps, Y0, n, eps0):
     A = n*Y0*eps0/(1.0 + n)
     x = eqps/eps0
-    return np.where(x >= 0.0,
-                    A*( (1.0 + x)**((n+1)/n) - 1.0 ),
-                    np.inf)
+    return A*( (1.0 + x)**((n+1)/n) - 1.0 )

--- a/optimism/material/J2Plastic.py
+++ b/optimism/material/J2Plastic.py
@@ -218,10 +218,10 @@ def update_state(elasticTrialStrain, stateOld, stateNewGuess, props, hardening_m
     lb = eqpsOld
     trialMises = 2 * props[PROPS_MU] * np.tensordot(TensorMath.dev(elasticTrialStrain), N)
     ub = eqpsOld + (trialMises - hardening_model.compute_flow_stress(eqpsOld))/(3.0*props[PROPS_MU])
-    eqps = ScalarRootFind.find_root(lambda e: r(elasticTrialStrain, e, eqpsOld, props, hardening_model),
-                                    eqpsGuess,
-                                    np.array([lb, ub]),
-                                    settings)
+    eqps, _ = ScalarRootFind.find_root(lambda e: r(elasticTrialStrain, e, eqpsOld, props, hardening_model),
+                                       eqpsGuess,
+                                       np.array([lb, ub]),
+                                       settings)
     DeltaEqps = eqps - eqpsOld
     DeltaPlasticStrain = DeltaEqps*N
     return np.hstack( (DeltaEqps, DeltaPlasticStrain.ravel()) )

--- a/optimism/material/J2Plastic.py
+++ b/optimism/material/J2Plastic.py
@@ -92,8 +92,7 @@ def make_properties(E, nu, Y0):
 def make_initial_state_finite_deformations(shape=(1,)):
     eqps = 0.0
     Fp = np.identity(3)
-    pointState = np.hstack((eqps, Fp.ravel()))
-    return np.tile(pointState, shape)
+    return np.hstack((eqps, Fp.ravel()))
 
 
 def make_initial_state_small_deformations(shape=(1,)):

--- a/optimism/material/J2Plastic.py
+++ b/optimism/material/J2Plastic.py
@@ -78,7 +78,6 @@ def create_material_model_functions(properties):
     density = properties.get('density')
 
     return MaterialModel(energy_density_function,
-                         energy_density_function,
                          compute_initial_state,
                          compute_state_new_function,
                          density)

--- a/optimism/material/LinearElastic.py
+++ b/optimism/material/LinearElastic.py
@@ -38,7 +38,6 @@ def create_material_model_functions(properties):
     density = properties.get('density')
 
     return MaterialModel(compute_energy_density = strain_energy,
-                         compute_output_energy_density = strain_energy,
                          compute_initial_state = make_initial_state,
                          compute_state_new = compute_state_new,
                          density = density)

--- a/optimism/material/LinearElastic.py
+++ b/optimism/material/LinearElastic.py
@@ -58,10 +58,8 @@ def _linear_elastic_energy_density(strain, internalVariables, props):
     return 0.5*kappa*traceStrain**2 + mu*np.tensordot(strainDev,strainDev)
 
 
-def make_initial_state(shape=(1,)):
-    dummy = 0.0
-    pointState = np.array([dummy])
-    return np.tile(pointState, shape)
+def make_initial_state():
+    return np.array([0.0])
 
 
 def _compute_state_new(strain, internalVariables, props):

--- a/optimism/material/LinearElastic.py
+++ b/optimism/material/LinearElastic.py
@@ -59,7 +59,7 @@ def _linear_elastic_energy_density(strain, internalVariables, props):
 
 
 def make_initial_state():
-    return np.array([0.0])
+    return np.array([])
 
 
 def _compute_state_new(strain, internalVariables, props):

--- a/optimism/material/MaterialModel.py
+++ b/optimism/material/MaterialModel.py
@@ -1,8 +1,8 @@
-from optimism.JaxConfig import *
-from optimism import TensorMath
+from collections import namedtuple
 
 MatProps = namedtuple('MatProps', ['props','num_props','num_states'])
 
 MaterialModel = namedtuple('MaterialModel',
-                           ['compute_energy_density', 'compute_output_energy_density',
-                            'compute_initial_state', 'compute_state_new', 'density'], defaults=(0.0,))
+                           ['compute_energy_density', 'compute_initial_state', 'compute_state_new',
+                            'density'],
+                           defaults=(0.0,))

--- a/optimism/material/Neohookean.py
+++ b/optimism/material/Neohookean.py
@@ -67,8 +67,8 @@ def _adagio_neohookean(dispGrad, internalVariables, props):
     return Wdev + Wvol
 
 
-def make_initial_state(shape=(1,)):
-    return np.zeros(shape)
+def make_initial_state():
+    return np.array([0.0])
 
 
 def _compute_state_new(dispGrad, internalVars, props):

--- a/optimism/material/Neohookean.py
+++ b/optimism/material/Neohookean.py
@@ -68,7 +68,7 @@ def _adagio_neohookean(dispGrad, internalVariables, props):
 
 
 def make_initial_state():
-    return np.array([0.0])
+    return np.array([])
 
 
 def _compute_state_new(dispGrad, internalVars, props):

--- a/optimism/material/Neohookean.py
+++ b/optimism/material/Neohookean.py
@@ -30,7 +30,6 @@ def create_material_model_functions(properties):
     density = properties.get('density')
 
     return MaterialModel(strain_energy,
-                         strain_energy,
                          make_initial_state,
                          compute_state_new,
                          density)

--- a/optimism/material/test/testJ2Plastic.py
+++ b/optimism/material/test/testJ2Plastic.py
@@ -201,7 +201,7 @@ class J2PlasticUniaxial(TestFixture):
 
         maxTime = 20.0
 
-        uniaxial = MaterialUniaxialSimulator.run(self.mat, constant_true_strain_rate, maxTime, steps=100)
+        uniaxial = MaterialUniaxialSimulator.run(self.mat, constant_true_strain_rate, maxTime, steps=10)
 
         logStrainHistory = np.log(1.0 + uniaxial.strainHistory[:,0,0])
         yieldStrain = self.Y0/self.E

--- a/optimism/test/testScalarRootFinder.py
+++ b/optimism/test/testScalarRootFinder.py
@@ -1,8 +1,10 @@
 from sys import float_info
+
+import jax
+import jax.numpy as np
 from scipy.optimize import minimize_scalar, root_scalar # for comparison
 from scipy.optimize import OptimizeResult
 
-from optimism.JaxConfig import *
 from optimism import ScalarRootFind
 from optimism.test import TestFixture
 
@@ -36,7 +38,7 @@ class ScalarRootFindTestFixture(TestFixture.TestFixture):
 
         
     def test_find_root_with_jit(self):
-        rtsafe_jit = jit(ScalarRootFind.find_root, static_argnums=(0,3))
+        rtsafe_jit = jax.jit(ScalarRootFind.find_root, static_argnums=(0,3))
         rootBracket = np.array([float_info.epsilon, 100.0])
         root = rtsafe_jit(f, self.rootGuess, rootBracket, self.settings)
         self.assertNear(root, self.rootExpected, 13)
@@ -63,7 +65,7 @@ class ScalarRootFindTestFixture(TestFixture.TestFixture):
         root = cube_root(4.0)
         self.assertNear(root, self.rootExpected, 13)
 
-        df = jacfwd(cube_root)
+        df = jax.jacfwd(cube_root)
         x = 3.0
         self.assertNear(df(x), x**(-2/3)/3, 13)
 
@@ -85,7 +87,7 @@ class ScalarRootFindTestFixture(TestFixture.TestFixture):
             return ScalarRootFind.find_root(lambda x: myfunc(x, a), 8.0,
                                             rootBracket, self.settings)
         x = np.array([1.0, 4.0, 9.0, 16.0])
-        F = jit(vmap(my_sqrt, 0))
+        F = jax.jit(jax.vmap(my_sqrt, 0))
         expectedRoots = np.array([1.0, 2.0, 3.0, 4.0])
         self.assertArrayNear(F(x), expectedRoots, 12)
 

--- a/optimism/test/testScalarRootFinder.py
+++ b/optimism/test/testScalarRootFinder.py
@@ -33,26 +33,29 @@ class ScalarRootFindTestFixture(TestFixture.TestFixture):
 
     def test_find_root(self):
         rootBracket = np.array([float_info.epsilon, 100.0])
-        root = ScalarRootFind.find_root(f, self.rootGuess, rootBracket, self.settings)
+        root, status = ScalarRootFind.find_root(f, self.rootGuess, rootBracket, self.settings)
+        self.assertTrue(status.converged)
         self.assertNear(root, self.rootExpected, 13)
 
         
     def test_find_root_with_jit(self):
         rtsafe_jit = jax.jit(ScalarRootFind.find_root, static_argnums=(0,3))
         rootBracket = np.array([float_info.epsilon, 100.0])
-        root = rtsafe_jit(f, self.rootGuess, rootBracket, self.settings)
+        root, status = rtsafe_jit(f, self.rootGuess, rootBracket, self.settings)
+        self.assertTrue(status.converged)
         self.assertNear(root, self.rootExpected, 13)
 
 
     def test_unbracketed_root_gives_nan(self):
         rootBracket = np.array([2.0, 100.0])
-        root = ScalarRootFind.find_root(f, self.rootGuess, rootBracket, self.settings)
+        root, _ = ScalarRootFind.find_root(f, self.rootGuess, rootBracket, self.settings)
         self.assertTrue(np.isnan(root))
 
         
     def test_find_root_converges_with_terrible_guess(self):
         rootBracket = np.array([float_info.epsilon, 200.0])
-        root = ScalarRootFind.find_root(f, 199.0, rootBracket, self.settings)
+        root, status = ScalarRootFind.find_root(f, 199.0, rootBracket, self.settings)
+        self.assertTrue(status.converged)
         self.assertNear(root, self.rootExpected, 13)
 
         
@@ -60,8 +63,10 @@ class ScalarRootFindTestFixture(TestFixture.TestFixture):
         myfunc = lambda x, a: x**3 - a
         def cube_root(a):
             rootBracket = np.array([float_info.epsilon, 100.0])
-            return ScalarRootFind.find_root(lambda x: myfunc(x, a), 8.0,
-                                            rootBracket, self.settings)
+            root, _ = ScalarRootFind.find_root(lambda x: myfunc(x, a), 8.0, rootBracket, 
+                                               self.settings)
+            return root
+                                            
         root = cube_root(4.0)
         self.assertNear(root, self.rootExpected, 13)
 
@@ -74,8 +79,10 @@ class ScalarRootFindTestFixture(TestFixture.TestFixture):
         myfunc = lambda x, a: x**2 - a
         def my_sqrt(a):
             rootBracket = np.array([float_info.epsilon, 100.0])
-            return ScalarRootFind.find_root(lambda x: myfunc(x, a), 8.0,
-                                            rootBracket, self.settings)
+            root, _ = ScalarRootFind.find_root(lambda x: myfunc(x, a), 8.0,
+                                               rootBracket, self.settings)
+            return root
+
         r = my_sqrt(9.0)
         self.assertNear(r, 3.0, 12)
 
@@ -84,8 +91,10 @@ class ScalarRootFindTestFixture(TestFixture.TestFixture):
         myfunc = lambda x, a: x**2 - a
         def my_sqrt(a):
             rootBracket = np.array([float_info.epsilon, 100.0])
-            return ScalarRootFind.find_root(lambda x: myfunc(x, a), 8.0,
-                                            rootBracket, self.settings)
+            root, _ = ScalarRootFind.find_root(lambda x: myfunc(x, a), 8.0,
+                                               rootBracket, self.settings)
+            return root
+
         x = np.array([1.0, 4.0, 9.0, 16.0])
         F = jax.jit(jax.vmap(my_sqrt, 0))
         expectedRoots = np.array([1.0, 2.0, 3.0, 4.0])
@@ -95,14 +104,16 @@ class ScalarRootFindTestFixture(TestFixture.TestFixture):
     def test_solves_when_left_bracket_is_solution(self):
         rootBracket = np.array([0.0, 1.0])
         guess = 3.0
-        root = ScalarRootFind.find_root(lambda x: x*(x**2 - 10.0), guess, rootBracket, self.settings)
+        root, status = ScalarRootFind.find_root(lambda x: x*(x**2 - 10.0), guess, rootBracket, self.settings)
+        self.assertTrue(status.converged)
         self.assertNear(root, 0.0, 12)
 
 
     def test_solves_when_right_bracket_is_solution(self):
         rootBracket = np.array([-1.0, 0.0])
         guess = 3.0
-        root = ScalarRootFind.find_root(lambda x: x*(x**2 - 10.0), guess, rootBracket, self.settings)
+        root, status = ScalarRootFind.find_root(lambda x: x*(x**2 - 10.0), guess, rootBracket, self.settings)
+        self.assertTrue(status.converged)
         self.assertNear(root, 0.0, 12)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Makes several simplifications to the material model interface, particularly for the plasticity model:

- Handle tiling of initial values of internal variables (to make copies for each quadrature point in each element) at the mechanics module level, instead of inside the material. This is a cleaner division of responsibilities, avoiding passing finite element model data to a material.
- Simplified the J2 plastic material: removed the conditional path where the caller could force the material to skip the internal variable update. I realized this could be effected by setting the tolerances identically for accepting the elastic trial solution and for the consistency solve. This eliminates the complexity of the extra conditional and eliminates a function form the interface of the material.
- Added a test that makes sure that if the material is called with updated internal variables, the update doesn't happen again.
- Remove some of the ugly wildcard imports. Bit by bit, I want to prune all of these.
- Remove unhelpful conditionals on hardening functions that returned infinities if the equivalent plastic strain went negative. The solver already prevents the equivalent plastic strain from ever decreasing with its bounds.