### PR TITLE
Specify CPU install of jax

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,6 @@ For details about the OptimiSM API, see the [documentation]().
 ## Contact
 
 OptimiSM was created and is maintained by Michael Tupek
-<mrtupek@sandia.gov> and Brandon Talamini <btalami@sandia.gov>.
+<tupek2@llnl.gov> and Brandon Talamini <talamini1@llnl.gov>.
 
 SCR#: 2709.0

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,7 @@ setuptools.setup(
     description='Rapid development platform for solid mechanics research using optimization tools',
     author="Michael Tupek and Brandon Talamini",
     author_email='talamini1@llnl.gov', # todo: make an email list
-    install_requires=['jax',
-                      'jaxlib',
+    install_requires=['jax[cpu]',
                       'scipy',
                       'matplotlib', # this is not strictly necessary
                       'netcdf4'],


### PR DESCRIPTION
We were not following the instructions for Jax, which caused us to have to install its dependency jaxlib by hand.

If we want to support GPU builds later, we can add another install option.

Fixes #36