### PR TITLE
using filled() method of the numpy masked array

### DIFF
--- a/optimism/ReadExodusMesh.py
+++ b/optimism/ReadExodusMesh.py
@@ -37,7 +37,7 @@ def _read_coordinates(exodusDataset):
     coordsX = exodusDataset.variables['coordx'][:]
     coordsY = exodusDataset.variables['coordy'][:]
     
-    return np.column_stack([coordsX, coordsY])
+    return np.column_stack([coordsX.filled(), coordsY.filled()])
 
 
 def _read_block_conns(exodusDataset, blockOrdinal):


### PR DESCRIPTION
using a masked array in newer jax (0.4.18) throws an error