### PR TITLE
Spack build

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ venv/
 # IDE files
 .idea/
 .vscode/
+
+# outputs from tests
+*.png
+loads
+.coverage

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ venv/
 *.png
 loads
 .coverage
+spack.lock
+.spack-env/

--- a/README.md
+++ b/README.md
@@ -124,6 +124,31 @@ pip=/usr/local/opt/python/bin/pip3
 SUITESPARSE_INCLUDE_DIR=$INC SUITESPARSE_LIBRARY_DIR=$LIB $pip install -e . sparse
 ```
 
+## Installation using spack
+Utilizing spack can alleviate some of the steps and headaches encountered in build described above to use spack to build optimism in a development environment, use the following instructions.
+
+If you don't already have spack, you can clone the git repo using the following command
+```
+git clone https://github.com/spack/spack.git
+```
+
+Once you have spack you can do the following in the optimism directory
+```
+source /path/to/spack/share/spack/setup-env.sh
+spack env activate .
+spack concretize -f
+spack install
+```
+
+The above will install all dependencies needed for optimism (including suite sparse and testing dependencies).
+
+Finally, you can install optimism via pip with
+```
+pip install -e .[sparse,test]
+```
+
+Note that in each new terminal you will need to source the ```setup-env.sh``` script from spack and activate the env in the optimism folder.
+
 ## Citing OptimiSM
 
 If you use OptimiSM in your research, please cite

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,6 @@ spack:
   - py-pytest-cov
   - py-pytest-xdist
   - py-scikit-sparse
-  - exodusii+fortran
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
   - py-pytest-cov
   - py-pytest-xdist
   - py-scikit-sparse
-  - exodusii
+  - exodusii+fortran
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,0 +1,18 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  # add package specs to the `specs` list
+  specs:
+  - python
+  - py-pip
+  - py-pytest
+  - py-pytest-cov
+  - py-pytest-xdist
+  - py-scikit-sparse
+  - exodusii
+  view: true
+  concretizer:
+    unify: true
+


### PR DESCRIPTION
Adding a simple spack build after I went through a few headaches setting up suitesparse on different systems. I've tested this on RHEL7 and ubuntu 22.

Added some instructions to the README as well. 

I was hoping to also get exodus.py in the loop but that thing is a nightmare to work with the exodusii spack build is pretty outdated.