### PR TITLE
Replace function removed from jax api with equivalent

### DIFF
--- a/optimism/phasefield/PhaseField.py
+++ b/optimism/phasefield/PhaseField.py
@@ -106,7 +106,7 @@ def plane_strain_gradient(gradU):
     dispGrad2D, phaseGrad2D = unpack_gradients_2D(gradU)
     dispGrad = tensor_2D_to_3D(dispGrad2D)
     phaseGrad = np.hstack((phaseGrad2D,0.0))
-    return np.row_stack((dispGrad,phaseGrad))
+    return np.vstack((dispGrad,phaseGrad))
 
 
 def plane_strain_element_gradient_transformation(elemGrads, elemShapes, elemVols, elemNodalDofs, elemNodalCoords):
@@ -119,7 +119,7 @@ def axisymmetric_gradient(gradU, U, coord):
     dispGrad = tensor_2D_to_3D(dispGrad2D)
     dispGrad = dispGrad.at[2,2].set(disp[0]/coord[0])
     phaseGrad = np.hstack((phaseGrad2D,0.0))
-    return np.row_stack((dispGrad, phaseGrad))
+    return np.vstack((dispGrad, phaseGrad))
 
 
 def axisymmetric_element_gradient_transformation(elemGrads, elemShapes, elemVols, elemNodalDofs, elemNodalCoords):


### PR DESCRIPTION
Fixes #79.

Our CI is now failing due to several errors caused by a new jax version. This PR fixes one class of these errors. The pipeline is not passing yet - another error type remains, as referenced by #78. I'll handle that in a separate PR.

I inspected the CI pipeline output and verified that this fixes all errors due to issue #79 and does not introduce any new errors. I will address #80 in another PR.