### PR TITLE
Fix gmres errors in CI triggered by new Scipy version

### DIFF
--- a/optimism/NewtonSolver.py
+++ b/optimism/NewtonSolver.py
@@ -34,8 +34,7 @@ def newton_step(residual, linear_op, x, settings=Settings(1e-2,100), precond=Non
     # it is allowed to modify the output in place.
     A = LinearOperator((sz,sz),
                        lambda v: onp.array(linear_op(v)))
-    r = residual(x)
-    rNorm = np.linalg.norm(r)
+    r = onp.array(residual(x))
 
     numIters = 0
     def callback(xk):
@@ -52,7 +51,7 @@ def newton_step(residual, linear_op, x, settings=Settings(1e-2,100), precond=Non
     else:
         M = None
         
-    dx, exitcode = gmres(A, onp.array(r), tol=relTol*rNorm, atol=0, M=M, callback_type='legacy', callback=callback, maxiter=maxIters)
+    dx, exitcode = gmres(A, r, rtol=relTol, atol=0, M=M, callback_type='legacy', callback=callback, maxiter=maxIters)
     print('Number of GMRES iters = ', numIters)
         
     return -dx, exitcode

--- a/optimism/NewtonSolver.py
+++ b/optimism/NewtonSolver.py
@@ -45,14 +45,14 @@ def newton_step(residual, linear_op, x, settings=Settings(1e-2,100), precond=Non
     relTol = settings.relative_gmres_tol
     maxIters = settings.max_gmres_iters
     
-    if precond==None:
-        dx, exitcode = gmres(A, onp.array(r), tol=relTol*rNorm, atol=0, callback_type='legacy', callback=callback, maxiter=maxIters)
-    else:
+    if precond is not None:
         # Another copy to a plain numpy array, see comment for A above.
         M = LinearOperator((sz,sz),
                            lambda v: onp.array(precond(v)))
-        dx, exitcode = gmres(A, onp.array(r), tol=relTol*rNorm, atol=0, M=M, callback_type='legacy', callback=callback, maxiter=maxIters)
+    else:
+        M = None
         
+    dx, exitcode = gmres(A, onp.array(r), tol=relTol*rNorm, atol=0, M=M, callback_type='legacy', callback=callback, maxiter=maxIters)
     print('Number of GMRES iters = ', numIters)
         
     return -dx, exitcode


### PR DESCRIPTION
We were passing JAX arrays to Scipy GMRES and duck typing was making it work. However, Scipy's GMRES [has been refactored](https://docs.scipy.org/doc/scipy/release/1.12.0-notes.html#scipy-sparse-improvements), and now it tries to modify some arrays in place. This is perfectly reasonable, but now the immutability of JAX arrays is causing a problem. I fixed this by making deep copies of the data to plain numpy arrays (including output of the matvec and preconditioner operators).

I also did some small maintenance in the nearby code. Please take a look at the change in the relative tolerance specification. I think it fixes a conceptual error, but it's going to cause a change in behavior. This modification also has the benefit of eliminating a deprecated parameter (Scipy is phasing out `tol` in favor of explicit `rtol` in the iterative solvers.)

Fixes #78 