### PR TITLE
Fix example with unrestrained block contacting and sliding

### DIFF
--- a/examples/friction/CornerSlide.py
+++ b/examples/friction/CornerSlide.py
@@ -171,7 +171,7 @@ class CornerSlide(MeshFixture):
             p = Objective.Params( p[0].at[0].set(forceRatio) )
             print('force ratio = ', forceRatio)
             
-            Uu = AlSolver.augmented_lagrange_solve(objective, Uu, p, alSettings, settings)
+            Uu = AlSolver.augmented_lagrange_solve(objective, Uu, p, alSettings, settings, useWarmStart=False)
 
             outputForce.append(forceRatio)
             outputDisp.append( np.average(self.create_field(Uu, p)[:,0]) )


### PR DESCRIPTION
This example no longer ran. Somehow, the warm start was being used with the force loading parameter, even though it should only be used for inhomogeneous displacement boundary conditions. My attempts to bisect and figure out when this example stopped working were unsuccessful because Jax has changed too much, and I don't care enough to reinstall old versions of Jax along the bisection. In any case, the fix is clear.

Turn off the warm start, the app now works exactly as expected. 

Just for reference, an alternative solution could be to put the loading parameter in a different parameter slot that doesn't get used in the warm start.