### PR TITLE
Have nonlinear solvers output a success flag.  This complicated custom vjp slightly.

### DIFF
--- a/examples/arch_bc/ArchBc.py
+++ b/examples/arch_bc/ArchBc.py
@@ -156,10 +156,10 @@ class ContactArch(MeshFixture):
 
             disp -= maxDisp/steps
             p = Objective.param_index_update(p, 0, disp)
-            Uu = EqSolver.nonlinear_equation_solve(objective,
-                                                   Uu,
-                                                   p,
-                                                   self.trSettings)
+            Uu, solverSuccess = EqSolver.nonlinear_equation_solve(objective,
+                                                                  Uu,
+                                                                  p,
+                                                                  self.trSettings)
             
             self.write_output(Uu, p, i)
 

--- a/examples/arch_bc/ArchTraction.py
+++ b/examples/arch_bc/ArchTraction.py
@@ -172,7 +172,7 @@ class TractionArch(MeshFixture):
 
             force += maxForce/steps
             p = Objective.param_index_update(p, 0, force)
-            Uu = EqSolver.nonlinear_equation_solve(objective, Uu, p, self.trSettings, solver_algorithm=solver)
+            Uu, solverSuccess = EqSolver.nonlinear_equation_solve(objective, Uu, p, self.trSettings, solver_algorithm=solver)
             
             self.write_output(Uu, p, i)
 
@@ -184,7 +184,7 @@ class TractionArch(MeshFixture):
 
                 force -= maxForce/steps
                 p = Objective.param_index_update(p, 0, force)
-                Uu = EqSolver.nonlinear_equation_solve(objective, Uu, p, self.trSettings, solver_algorithm=solver)
+                Uu, solverSuccess = EqSolver.nonlinear_equation_solve(objective, Uu, p, self.trSettings, solver_algorithm=solver)
             
                 self.write_output(Uu, p, i)
         

--- a/examples/configurational_forces/CrackConfigurationalForce.py
+++ b/examples/configurational_forces/CrackConfigurationalForce.py
@@ -132,8 +132,7 @@ def run():
         appliedK += 1.0
         p = Objective.param_index_update(p, 0, appliedK)
 
-        Uu = EquationSolver.nonlinear_equation_solve(objective, Uu, p, solverSettings)
-
+        Uu, solverSuccess = EquationSolver.nonlinear_equation_solve(objective, Uu, p, solverSettings)
         
         Wu = np.zeros_like(Uu)
         _, configForcesOnUnknowns = sensit(Wu, Uu, p, mesh)

--- a/examples/eigenvalue_sensitivity/nonlinear_elasticity_eigenvalue_sensitivity.ipynb
+++ b/examples/eigenvalue_sensitivity/nonlinear_elasticity_eigenvalue_sensitivity.ipynb
@@ -414,7 +414,7 @@
     "\n",
     "force = 2.0\n",
     "p = Objective.param_index_update(p, 0, force) # put current total force in parameter set\n",
-    "Uu = EquationSolver.nonlinear_equation_solve(objective, Uu, p, solverSettings, useWarmStart=False)\n"
+    "Uu, solverSuccess = EquationSolver.nonlinear_equation_solve(objective, Uu, p, solverSettings, useWarmStart=False)\n"
    ]
   },
   {
@@ -718,7 +718,7 @@
     "df = 1e-4\n",
     "forcePlus = force + df\n",
     "p = Objective.param_index_update(p, 0, forcePlus)\n",
-    "UuPlus = EquationSolver.nonlinear_equation_solve(objective, Uu, p, solverSettings, useWarmStart=False)"
+    "UuPlus, solverSuccess = EquationSolver.nonlinear_equation_solve(objective, Uu, p, solverSettings, useWarmStart=False)"
    ]
   },
   {

--- a/examples/euler_buckle/EulerBuckle.py
+++ b/examples/euler_buckle/EulerBuckle.py
@@ -154,7 +154,7 @@ class EulerBeam(MeshFixture):
             print('LOAD STEP ', i)
             force += maxForce/steps
             p = Objective.param_index_update(p, 0, force)
-            Uu = EqSolver.nonlinear_equation_solve(objective, Uu, p, self.trSettings, solver_algorithm=solver)
+            Uu, solverSuccess = EqSolver.nonlinear_equation_solve(objective, Uu, p, self.trSettings, solver_algorithm=solver)
 
             self.write_output(Uu, p, i)
 
@@ -165,7 +165,7 @@ class EulerBeam(MeshFixture):
                 print('LOAD STEP ', i)
                 force -= maxForce/steps
                 p = Objective.param_index_update(p, 0, force)
-                Uu = EqSolver.nonlinear_equation_solve(objective, Uu, p, self.trSettings, solver_algorithm=solver)
+                Uu, solverSuccess = EqSolver.nonlinear_equation_solve(objective, Uu, p, self.trSettings, solver_algorithm=solver)
 
                 self.write_output(Uu, p, i)
 

--- a/examples/hemisphere_cap/hemisphere_plastic_disp_control.py
+++ b/examples/hemisphere_cap/hemisphere_plastic_disp_control.py
@@ -156,8 +156,7 @@ class TractionArch():
 
             disp += maxDisp/steps
             p = Objective.param_index_update(p, 0, disp)
-            Uu = EqSolver.nonlinear_equation_solve(objective, Uu, p, self.trSettings)
-
+            Uu, solverSuccess = EqSolver.nonlinear_equation_solve(objective, Uu, p, self.trSettings)
             
             U = self.dofManager.create_field(Uu, self.get_ubcs(p))
             ivs = self.bvpFuncs.\
@@ -175,7 +174,7 @@ class TractionArch():
 
                 disp -= maxDisp/steps
                 p = Objective.param_index_update(p, 0, disp)
-                Uu = EqSolver.nonlinear_equation_solve(objective, Uu, p, self.trSettings)
+                Uu, solverSuccess = EqSolver.nonlinear_equation_solve(objective, Uu, p, self.trSettings)
 
                 U = self.dofManager.create_field(Uu, self.get_ubcs(p))
                 ivs = self.bvpFuncs.\

--- a/examples/hemisphere_cap/hemisphere_plastic_load_control.py
+++ b/examples/hemisphere_cap/hemisphere_plastic_load_control.py
@@ -197,7 +197,7 @@ class TractionArch():
 
             force += maxForce/steps
             p = Objective.param_index_update(p, 0, force)
-            Uu = EqSolver.nonlinear_equation_solve(objective, Uu, p, self.trSettings)
+            Uu, solverSuccess = EqSolver.nonlinear_equation_solve(objective, Uu, p, self.trSettings)
 
             U = self.dofManager.create_field(Uu, self.get_ubcs(p))
             ivs = self.bvpFuncs.compute_updated_internal_variables(U, p[1])
@@ -214,7 +214,7 @@ class TractionArch():
 
                 force -= maxForce/steps
                 p = Objective.param_index_update(p, 0, force)
-                Uu = EqSolver.nonlinear_equation_solve(objective, Uu, p, self.trSettings)
+                Uu, solverSuccess = EqSolver.nonlinear_equation_solve(objective, Uu, p, self.trSettings)
 
                 U = self.dofManager.create_field(Uu, self.get_ubcs(p))
                 ivs = self.bvpFuncs.compute_updated_internal_variables(U, p[1])

--- a/examples/inverse/BuckleInverse.py
+++ b/examples/inverse/BuckleInverse.py
@@ -221,7 +221,7 @@ class Buckle:
             endDispOrTraction = maxDispOrTraction*(i+1)/N
 
             p = Objective.param_index_update(p, 0, np.array([endDispOrTraction, 0.0]))
-            self.Uu = EquationSolver.nonlinear_equation_solve(self.objective, self.Uu, p, settings)
+            self.Uu, solverSuccess = EquationSolver.nonlinear_equation_solve(self.objective, self.Uu, p, settings)
 
             # post process
             print('step ', i)

--- a/examples/multi_material_tutorial/optimism_tutorial.ipynb
+++ b/examples/multi_material_tutorial/optimism_tutorial.ipynb
@@ -801,7 +801,7 @@
     "p = Objective.param_index_update(p, 0, appliedDisp)\n",
     "\n",
     "# Find unknown displacements by minimizing the objective\n",
-    "Uu = EquationSolver.nonlinear_equation_solve(objective, Uu, p, solverSettings)\n",
+    "Uu, solverSuccess = EquationSolver.nonlinear_equation_solve(objective, Uu, p, solverSettings)\n",
     "\n"
    ]
   },

--- a/examples/multi_material_tutorial/uniaxial_two_material.py
+++ b/examples/multi_material_tutorial/uniaxial_two_material.py
@@ -144,7 +144,7 @@ appliedDisp = L*0.003
 p = Objective.param_index_update(p, 0, appliedDisp)
 
 # Find unknown displacements by minimizing the objective
-Uu = EquationSolver.nonlinear_equation_solve(objective, Uu, p, solverSettings)
+Uu, solverSuccess = EquationSolver.nonlinear_equation_solve(objective, Uu, p, solverSettings)
 
 # update the state variables in the new equilibrium configuration
 U = create_field(Uu, p)

--- a/examples/surfing_fracture/SurfingFracture.py
+++ b/examples/surfing_fracture/SurfingFracture.py
@@ -462,11 +462,11 @@ class SurfingProblem:
                 print("------------------------------")
                 
                 print("Minimizing disp: objective = ", dispObjective.get_value(UuDisp))
-                UuDisp = EqSolver.nonlinear_equation_solve(dispObjective,
-                                                           UuDisp,
-                                                           p,
-                                                           dispSettings,
-                                                           useWarmStart=False)
+                UuDisp, solverSuccess = EqSolver.nonlinear_equation_solve(dispObjective,
+                                                                          UuDisp,
+                                                                          p,
+                                                                          dispSettings,
+                                                                          useWarmStart=False)
                 
                 Uu = Uu.at[self.dispIds].set(UuDisp)
                 print("Minimized disp: objective = ", dispObjective.get_value(UuDisp))

--- a/examples/uniaxial/Uniaxial.py
+++ b/examples/uniaxial/Uniaxial.py
@@ -167,7 +167,7 @@ class Uniaxial:
             xDisp = i/N*maxDisp
             p = Objective.param_index_update(p, 0, xDisp)
             
-            Uu = EqSolver.nonlinear_equation_solve(objective, Uu, p, settings)
+            Uu, solverSuccess = EqSolver.nonlinear_equation_solve(objective, Uu, p, settings)
             
             state = self.mechanicsFunctions.\
                 compute_updated_internal_variables(self.create_field(Uu, p), p[1])

--- a/examples/uniaxial_dynamic/UniaxialDynamic.py
+++ b/examples/uniaxial_dynamic/UniaxialDynamic.py
@@ -208,11 +208,11 @@ class UniaxialDynamic:
             #print('Predicted Vx = \n', self.create_field(Vu,p)[:,0])
             p = Objective.param_index_update(p, 5, UuPredicted)
 
-            Uu = EquationSolver.nonlinear_equation_solve(objective,
-                                                         Uu,
-                                                         p,
-                                                         solverSettings,
-                                                         useWarmStart=False)
+            Uu, solverSuccess = EquationSolver.nonlinear_equation_solve(objective,
+                                                                        Uu,
+                                                                        p,
+                                                                        solverSettings,
+                                                                        useWarmStart=False)
 
             UuCorrection = Uu - UuPredicted
             #print('Corrected Ux = \n', self.create_field(UuCorrection,p)[:,0])

--- a/optimism/TrustRegionSPG.py
+++ b/optimism/TrustRegionSPG.py
@@ -342,7 +342,7 @@ def bound_constrained_trust_region_minimize(objective, x, bounds, settings, call
     if is_converged(objective, x, 0.0, 0.0, prevOptimality, prevOptimality, 0,
                     trSize, settings):
         if callback: callback(x, objective)
-        return x
+        return x, True
 
     # Set guess for first cauchy point step length
     gHg = g@objective.hessian_vec(x, g)
@@ -391,7 +391,7 @@ def bound_constrained_trust_region_minimize(objective, x, bounds, settings, call
                         realOptimality, modelOptimality, spgIters, trSizeUsed,
                         settings):
             if callback: callback(y, objective)
-            return y
+            return y, True
         
         modelImprove = -modelObjective
         realImprove = -realObjective
@@ -445,14 +445,14 @@ def bound_constrained_trust_region_minimize(objective, x, bounds, settings, call
             else:
                 print("The trust region is still too small.  Accepting, but be careful.")
                 if callback: callback(x, objective)
-                return x
+                return x, False
                     
     print("Reached the maximum number of trust region iterations.")
     if settings.check_stability:
         objective.check_stability(x)
 
         if callback: callback(x, objective)
-    return x
+    return x, False
 
 
 def solve(objective, x0, p, lowerBounds, upperBounds, settings, callback=None,
@@ -477,8 +477,8 @@ def solve(objective, x0, p, lowerBounds, upperBounds, settings, callback=None,
 
     bounds = np.column_stack((lBar, uBar))
         
-    xBar = bound_constrained_trust_region_minimize(objective, xBar0, bounds, settings,
+    xBar, solverSuccess = bound_constrained_trust_region_minimize(objective, xBar0, bounds, settings,
                                                    callback=callback)
     
-    return objective.invScaling * xBar
+    return objective.invScaling * xBar, solverSuccess
     

--- a/optimism/inverse/NonlinearSolve.py
+++ b/optimism/inverse/NonlinearSolve.py
@@ -9,7 +9,7 @@ from optimism import WarmStart
 def nonlinear_solve(mechanicalEnergy, settings, UuGuess, designParams):
     p = Objective.param_index_update(mechanicalEnergy.p, 2, designParams)
     return EquationSolver.nonlinear_equation_solve(mechanicalEnergy,
-                                                   UuGuess, p, settings)
+                                                   UuGuess, p, settings)[0]
 
 
 def nonlinear_solve_f(mechanicalEnergy, settings, UuGuess, designParams):
@@ -23,13 +23,13 @@ def nonlinear_solve_b(mechanicalEnergy, settings, rdata, v):
     
     hess_vec_func = lambda w: mechanicalEnergy.hessian_vec(Uu, w)
     
-    results = EquationSolver.solve_trust_region_minimization(0.0*Uu,
-                                                             v,
-                                                             hess_vec_func,
-                                                             mechanicalEnergy.apply_precond,
-                                                             lambda x: x,
-                                                             np.inf,
-                                                             settings)
+    results,_ = EquationSolver.solve_trust_region_minimization(0.0*Uu,
+                                                               v,
+                                                               hess_vec_func,
+                                                               mechanicalEnergy.apply_precond,
+                                                               lambda x: x,
+                                                               np.inf,
+                                                               settings)
     
     lam = results[0]
     return (np.zeros_like(Uu)*v[0], mechanicalEnergy.vec_jacobian_p2(Uu, lam)[0])
@@ -45,11 +45,11 @@ def nonlinear_solve_with_state(mechanicalEnergy, settings, UuGuess, p):
     mechanicalEnergy.update_precond(UuGuess)
     UuGuess += WarmStart.warm_start_increment_jax_safe(mechanicalEnergy, UuGuess, p[0])
 
-    Uu = EquationSolver.nonlinear_equation_solve(mechanicalEnergy,
-                                                 UuGuess,
-                                                 p,
-                                                 settings,
-                                                 useWarmStart=False)
+    Uu, solverSuccess = EquationSolver.nonlinear_equation_solve(mechanicalEnergy,
+                                                                UuGuess,
+                                                                p,
+                                                                settings,
+                                                                useWarmStart=False)
     return Uu
 
 

--- a/optimism/inverse/test/test_Hyperelastic_gradient_checks.py
+++ b/optimism/inverse/test/test_Hyperelastic_gradient_checks.py
@@ -73,7 +73,7 @@ class NeoHookeanGlobalMeshAdjointSolveFixture(FiniteDifferenceFixture):
 
         for step in range(1, self.steps+1):
             p = Objective.param_index_update(p, 0, step*Ubc_inc)
-            Uu = EqSolver.nonlinear_equation_solve(self.objective, Uu, p, EqSolver.get_settings(), useWarmStart=False)
+            Uu, solverSuccess = EqSolver.nonlinear_equation_solve(self.objective, Uu, p, EqSolver.get_settings(), useWarmStart=False)
             storedState.append((Uu, p))
         
         return storedState

--- a/optimism/inverse/test/test_J2Plastic_gradient_checks.py
+++ b/optimism/inverse/test/test_J2Plastic_gradient_checks.py
@@ -75,7 +75,7 @@ class J2GlobalMeshAdjointSolveFixture(FiniteDifferenceFixture):
 
         for step in range(1, self.steps+1):
             p = Objective.param_index_update(p, 0, step*Ubc_inc)
-            Uu = EqSolver.nonlinear_equation_solve(self.objective, Uu, p, EqSolver.get_settings(), useWarmStart=False)
+            Uu, solverSuccess = EqSolver.nonlinear_equation_solve(self.objective, Uu, p, EqSolver.get_settings(), useWarmStart=False)
             U = self.dofManager.create_field(Uu, p.bc_data)
             ivs = mechFuncs.compute_updated_internal_variables(U, p.state_data)
             p = Objective.param_index_update(p, 1, ivs)

--- a/optimism/inverse/test/test_J2Plastic_inverse.py
+++ b/optimism/inverse/test/test_J2Plastic_inverse.py
@@ -164,7 +164,7 @@ class J2GlobalMeshUpdateGradsFixture(MeshFixture):
             return cls.mechFuncs.compute_strain_energy(U, internalVariables)
 
         objective = Objective.Objective(compute_energy, UuGuess, p)
-        cls.Uu = EqSolver.nonlinear_equation_solve(objective, UuGuess, p, EqSolver.get_settings(), useWarmStart=False)
+        cls.Uu, solverSuccess = EqSolver.nonlinear_equation_solve(objective, UuGuess, p, EqSolver.get_settings(), useWarmStart=False)
         U = cls.dofManager.create_field(cls.Uu, cls.Ubc)
         cls.ivs = cls.mechFuncs.compute_updated_internal_variables(U, cls.ivs_prev)
 

--- a/optimism/material/MaterialUniaxialSimulator.py
+++ b/optimism/material/MaterialUniaxialSimulator.py
@@ -74,7 +74,7 @@ def run(materialModel, strain_history, maxTime, steps=10):
         print(f'Step {i}')
         p = Objective.param_index_update(p, 0, uniaxialStrainHistory[i])
 
-        freeStrains = EqSolver.nonlinear_equation_solve(o, freeStrains, p, solverSettings, useWarmStart=True)
+        freeStrains, solverSuccess = EqSolver.nonlinear_equation_solve(o, freeStrains, p, solverSettings, useWarmStart=True)
         strain = makeStrainTensor_(freeStrains, p)
         internalVariables = update(strain, internalVariables, dt)
         energyDensity,stress = converged_energy_density_and_stress(strain, internalVariables, dt)

--- a/optimism/material/test/test_J2Plastic.py
+++ b/optimism/material/test/test_J2Plastic.py
@@ -311,8 +311,9 @@ class PlasticityOnMesh(MeshFixture):
         
         objective = Objective.Objective(compute_energy, UuGuess, p)
         
-        Uu = EqSolver.nonlinear_equation_solve(objective, UuGuess, p, EqSolver.get_settings(), useWarmStart=False)
-
+        Uu, solverSuccess = EqSolver.nonlinear_equation_solve(objective, UuGuess, p, EqSolver.get_settings(), useWarmStart=False)
+        self.assertTrue(solverSuccess)
+        
         U = dofManager.create_field(Uu, Ubc)
 
         dispGrads = FunctionSpace.compute_field_gradient(fs, U)

--- a/optimism/test/test_AxisymmPatchTest.py
+++ b/optimism/test/test_AxisymmPatchTest.py
@@ -68,7 +68,7 @@ class AxisymmPatchTest(MeshFixture.MeshFixture):
             U = dofManager.create_field(Uu, Ubc)
             return self.compute_energy(U, self.internals)
         
-        Uu = newton_solve(objective, dofManager.get_unknown_values(V))
+        Uu, solverSuccess = newton_solve(objective, dofManager.get_unknown_values(V))
 
         U = dofManager.create_field(Uu, Ubc)
             

--- a/optimism/test/test_EquationSolver.py
+++ b/optimism/test/test_EquationSolver.py
@@ -21,21 +21,25 @@ class EquationSolverFixture(TestFixture):
         self.obj = Objective.Objective(energy, self.x, self.p)
         
     def test_trust_region_equation_solver(self):
-        sol = es.trust_region_least_squares_solve(self.obj, self.x, self.settings)
+        sol, solverSuccess = es.trust_region_least_squares_solve(self.obj, self.x, self.settings)
+        self.assertTrue(solverSuccess)
         self.assertNear( np.linalg.norm( self.obj.gradient(sol)), 0, 7 )
 
     def test_trust_region_optimizer(self):
-        sol = es.nonlinear_equation_solve(self.obj, self.x, self.p, self.settings)
+        sol, solverSuccess = es.nonlinear_equation_solve(self.obj, self.x, self.p, self.settings)
+        self.assertTrue(solverSuccess)
         self.assertNear( np.linalg.norm( self.obj.gradient(sol)), 0, 7 )
 
     def test_trust_region_optimizer_with_preconditioned_inner_products(self):
         settings=es.get_settings(use_preconditioned_inner_product_for_cg=True)
-        sol = es.nonlinear_equation_solve(self.obj, self.x, self.p, settings)
+        sol, solverSuccess = es.nonlinear_equation_solve(self.obj, self.x, self.p, settings)
+        self.assertTrue(solverSuccess)
         self.assertNear( np.linalg.norm( self.obj.gradient(sol)), 0, 7 )
 
     def test_trust_region_incremental_optimizer(self):
         incrementalSettings = es.get_settings(use_incremental_objective=True)
-        sol = es.nonlinear_equation_solve(self.obj, self.x, self.p, incrementalSettings)
+        sol, solverSuccess = es.nonlinear_equation_solve(self.obj, self.x, self.p, incrementalSettings)
+        self.assertTrue(solverSuccess)
         self.assertNear( np.linalg.norm( self.obj.gradient(sol)), 0, 7 )
 
 if __name__ == '__main__':

--- a/optimism/test/test_Newmark.py
+++ b/optimism/test/test_Newmark.py
@@ -184,11 +184,11 @@ class DynamicsFixture(MeshFixture.MeshFixture):
         UuPredicted, Vu = self.dynamicsFunctions.predict(Uu, Vu, Au, dt)
         objective.p = Objective.param_index_update(objective.p, 5, UuPredicted)
 
-        Uu = EquationSolver.nonlinear_equation_solve(objective,
-                                                     UuPredicted,
-                                                     objective.p,
-                                                     trSettings,
-                                                     useWarmStart=False)
+        Uu, solverSuccess = EquationSolver.nonlinear_equation_solve(objective,
+                                                                    UuPredicted,
+                                                                    objective.p,
+                                                                    trSettings,
+                                                                    useWarmStart=False)
 
         UuCorrection = Uu - UuPredicted
         Vu, Au = self.dynamicsFunctions.correct(UuCorrection, Vu, Au, dt)
@@ -299,11 +299,11 @@ class DynamicPatchTest(MeshFixture.MeshFixture):
 
             # The predictor value is exact.
             # Choose a bad initial guess (zero) to force an actual solve.
-            Uu = EquationSolver.nonlinear_equation_solve(objective,
-                                                         dofManager.get_unknown_values(UPrediction),
-                                                         objective.p,
-                                                         trSettings,
-                                                         useWarmStart=False)
+            Uu, solverSuccess = EquationSolver.nonlinear_equation_solve(objective,
+                                                                        dofManager.get_unknown_values(UPrediction),
+                                                                        objective.p,
+                                                                        trSettings,
+                                                                        useWarmStart=False)
 
             U = dofManager.create_field(Uu, dofManager.get_bc_values(V*t))
             UCorrection = U - UPrediction
@@ -365,11 +365,11 @@ class DynamicPatchTest(MeshFixture.MeshFixture):
 
             # The predictor value is exact.
             # Choose a bad initial guess (zero) to force an actual solve.
-            Uu = EquationSolver.nonlinear_equation_solve(objective,
-                                                         dofManager.get_unknown_values(UPrediction),
-                                                         objective.p,
-                                                         trSettings,
-                                                         useWarmStart=False)
+            Uu, solverSuccess = EquationSolver.nonlinear_equation_solve(objective,
+                                                                        dofManager.get_unknown_values(UPrediction),
+                                                                        objective.p,
+                                                                        trSettings,
+                                                                        useWarmStart=False)
 
             U = dofManager.create_field(Uu)
             UCorrection = U - UPrediction

--- a/optimism/test/test_PatchTest.py
+++ b/optimism/test/test_PatchTest.py
@@ -62,7 +62,8 @@ class LinearPatchTestLinearElements(MeshFixture.MeshFixture):
             return self.compute_energy(U, self.internals)
         
         with Timer(name="NewtonSolve"):
-            Uu = newton_solve(objective, dofManager.get_unknown_values(self.U))
+            Uu, solverSuccess = newton_solve(objective, dofManager.get_unknown_values(self.U))
+            self.assertTrue(solverSuccess)
 
         self.U = dofManager.create_field(Uu, Ubc)
             
@@ -97,9 +98,10 @@ class LinearPatchTestLinearElements(MeshFixture.MeshFixture):
             return internalPotential + loadPotential
         
         with Timer(name="NewtonSolve"):
-            Uu = newton_solve(objective, dofManager.get_unknown_values(self.U))
+            Uu, solverSuccess = newton_solve(objective, dofManager.get_unknown_values(self.U))
+            self.assertTrue(solverSuccess)
 
-            self.U = dofManager.create_field(Uu, Ubc)
+        self.U = dofManager.create_field(Uu, Ubc)
 
         # exact solution
         modulus1 = (1.0 - nu**2)/E
@@ -153,7 +155,8 @@ class LinearPatchTestQuadraticElements(MeshFixture.MeshFixture):
             return self.compute_energy(U, self.internals)
         
         with Timer(name="NewtonSolve"):
-            Uu = newton_solve(objective, dofManager.get_unknown_values(self.UTarget))
+            Uu, solverSuccess = newton_solve(objective, dofManager.get_unknown_values(self.UTarget))
+            self.assertTrue(solverSuccess)
 
         U = dofManager.create_field(Uu, Ubc)
             
@@ -186,7 +189,8 @@ class LinearPatchTestQuadraticElements(MeshFixture.MeshFixture):
             return self.compute_energy(U, self.internals)
         
         with Timer(name="NewtonSolve"):
-            Uu = newton_solve(objective, dofManager.get_unknown_values(self.UTarget))
+            Uu, solverSuccess = newton_solve(objective, dofManager.get_unknown_values(self.UTarget))
+            self.assertTrue(solverSuccess)
 
         U = dofManager.create_field(Uu, Ubc)
             
@@ -249,7 +253,8 @@ class QuadraticPatchTestQuadraticElements(MeshFixture.MeshFixture):
             return self.compute_energy(U, self.internals) + constant_body_force_potential(U, self.internals, self.b)
         
         with Timer(name="NewtonSolve"):
-            Uu = newton_solve(objective, 0.0*self.dofManager.get_unknown_values(self.UTarget))
+            Uu, solverSuccess = newton_solve(objective, 0.0*self.dofManager.get_unknown_values(self.UTarget))
+            self.assertTrue(solverSuccess)
 
         U = self.dofManager.create_field(Uu, Ubc)
 

--- a/optimism/test/test_PatchTestPou.py
+++ b/optimism/test/test_PatchTestPou.py
@@ -227,7 +227,8 @@ class PatchTestQuadraticElements(MeshFixture.MeshFixture):
 
             return totalEnergy
 
-        Uu = newton_solve(objective_poly, self.dofManager.get_unknown_values(0.0*self.UTarget))
+        Uu, solverSuccess = newton_solve(objective_poly, self.dofManager.get_unknown_values(0.0*self.UTarget))
+        self.assertTrue(solverSuccess)
 
         self.write_output(Uu, Ubc, 0)
 

--- a/optimism/test/test_ReadExodusMesh.py
+++ b/optimism/test/test_ReadExodusMesh.py
@@ -137,7 +137,9 @@ class TestMeshReadPatchTest(TestFixture.TestFixture):
         
         grad_func = jit(grad(objective))
         
-        Uu = newton_solve(objective, dofManager.get_unknown_values(U))
+        Uu, solverSuccess = newton_solve(objective, dofManager.get_unknown_values(U))
+        self.assertTrue(solverSuccess)
+
         U = dofManager.create_field(Uu, Ubc)
            
         dispGrads = FunctionSpace.compute_field_gradient(self.fs, U)

--- a/optimism/test/test_ReadMesh.py
+++ b/optimism/test/test_ReadMesh.py
@@ -124,6 +124,7 @@ class TestMeshReadPatchTest(TestFixture.TestFixture):
         
         Uu, solverSuccess = newton_solve(objective, dofManager.get_unknown_values(U))
         self.assertTrue(solverSuccess)
+
         U = dofManager.create_field(Uu, Ubc)
             
         dispGrads = FunctionSpace.compute_field_gradient(self.fs, U)
@@ -157,9 +158,10 @@ class TestMeshReadPatchTest(TestFixture.TestFixture):
             return internalPotential + loadPotential
         
         with Timer(name="NewtonSolve"):
-            Uu = newton_solve(objective, dofManager.get_unknown_values(U))
+            Uu, solverSuccess = newton_solve(objective, dofManager.get_unknown_values(U))
+            self.assertTrue(solverSuccess)
 
-            U = dofManager.create_field(Uu, Ubc)
+        U = dofManager.create_field(Uu, Ubc)
 
         # exact solution
         modulus1 = (1.0 - self.nu**2)/self.E

--- a/optimism/test/test_ReadMesh.py
+++ b/optimism/test/test_ReadMesh.py
@@ -122,7 +122,8 @@ class TestMeshReadPatchTest(TestFixture.TestFixture):
         
         grad_func = jit(grad(objective))
         
-        Uu = newton_solve(objective, dofManager.get_unknown_values(U))
+        Uu, solverSuccess = newton_solve(objective, dofManager.get_unknown_values(U))
+        self.assertTrue(solverSuccess)
         U = dofManager.create_field(Uu, Ubc)
             
         dispGrads = FunctionSpace.compute_field_gradient(self.fs, U)

--- a/optimism/test/test_Traction.py
+++ b/optimism/test/test_Traction.py
@@ -70,7 +70,8 @@ class TractionPatch(MeshFixture.MeshFixture):
             return internalPotential + loadPotential
         
         with Timer(name="NewtonSolve"):
-            Uu = newton_solve(objective, dofManager.get_unknown_values(self.UTarget))
+            Uu, solverSuccess = newton_solve(objective, dofManager.get_unknown_values(self.UTarget))
+            self.assertTrue(solverSuccess)
 
         U = dofManager.create_field(Uu, Ubc)
             

--- a/optimism/test/test_TrustRegionSPG.py
+++ b/optimism/test/test_TrustRegionSPG.py
@@ -254,8 +254,9 @@ class TestTrustRegionSPGFixture(TestFixture.TestFixture):
     def test_trust_region_spg_on_unbounded_problem(self):
         lb = np.full(self.x.shape, -np.inf)
         ub = np.full(self.x.shape, np.inf)
-        sol = TrustRegionSPG.solve(self.obj, self.x, self.p, lb, ub,
-                                   self.settings, useWarmStart=False)
+        sol, solverSuccess = TrustRegionSPG.solve(self.obj, self.x, self.p, lb, ub,
+                                                  self.settings, useWarmStart=False)
+        self.assertTrue(solverSuccess)
         self.assertNear(np.linalg.norm(self.obj.gradient(sol)), 0, 7)
 
         # BT: This solver is converging to the same point as the
@@ -305,9 +306,9 @@ class TestTrustRegionSPGRosenbrock(TestFixture.TestFixture):
     def test_spg_on_rosenbrock(self):
         lb = np.full(self.x.shape, -np.inf)
         ub = np.full(self.x.shape, np.inf)
-        sol = TrustRegionSPG.solve(self.obj, self.x, self.p, lb, ub,
-                                   self.settings, useWarmStart=False)
-        #print('sol', sol)
+        sol, solverSuccess = TrustRegionSPG.solve(self.obj, self.x, self.p, lb, ub,
+                                                  self.settings, useWarmStart=False)
+        self.assertTrue(solverSuccess)
         self.assertNear(np.linalg.norm(self.obj.gradient(sol)), 0, 7)
         self.assertArrayNear(sol, np.ones(sol.shape), 4)
 

--- a/optimism/test/test_TrustRegionSPG.py
+++ b/optimism/test/test_TrustRegionSPG.py
@@ -272,8 +272,9 @@ class TestTrustRegionSPGFixture(TestFixture.TestFixture):
 
     def no_test_cgunbound(self):
         settings = EquationSolver.get_settings()
-        sol = EquationSolver.nonlinear_equation_solve(self.obj, self.x, self.p,
-                                                      settings, useWarmStart=False)
+        sol, solverSuccess = EquationSolver.nonlinear_equation_solve(self.obj, self.x, self.p,
+                                                                     settings, useWarmStart=False)
+        self.assertTrue(solverSuccess)
         self.assertNear(np.linalg.norm(self.obj.gradient(sol)), 0, 7)
 
 
@@ -313,8 +314,9 @@ class TestTrustRegionSPGRosenbrock(TestFixture.TestFixture):
 
     def no_test_steihaug_on_rosenbrock(self):
         settings = EquationSolver.get_settings()
-        sol = EquationSolver.nonlinear_equation_solve(self.obj, self.x, self.p,
-                                                      settings, useWarmStart=False)
+        sol, solverSuccess = EquationSolver.nonlinear_equation_solve(self.obj, self.x, self.p,
+                                                                     settings, useWarmStart=False)
+        self.assertTrue(solverSuccess)
         print('sol', sol)
         
         


### PR DESCRIPTION
Also do not increase the penalty when the constrain ncp error is already really small compared to the tolerance. Previously, the penalty would just keep going up and up, and the constraint was already essentially fully enforced. This made the minimization problem too stiff.

