### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
                       'matplotlib', # this is not strictly necessary
                       'metis',
                       'netcdf4',
-                      'scipy',],
+                      'scipy==1.14.1',],
     #tests_require=[], # could put chex and pytest here
     extras_require={'sparse': ['scikit-sparse'],
                     'test': ['pytest', 'pytest-cov', 'pytest-xdist'],


### PR DESCRIPTION
Add a scipy version restriction after encountering terrible errors in a plato build. 

The culprit was a method call somewhere in ```Objective.py``` with an error similar to 

```terminate called after throwing an instance of 'pybind11::error_already_set'
  what():  TypeError: primal and tangent arguments to jax.jvp do not match; dtypes must be equal, or in case of int/bool primal dtype the tangent dtype must be float0.Got primal dtype float64 and so expected tangent dtype float64, but got tangent dtype int8 instead.
__notes__ (len=1):```